### PR TITLE
Refactor Toolchain: Centralize Dual Output Build for both ESM and CJS with Mono Package 

### DIFF
--- a/.changeset/new-views-marry.md
+++ b/.changeset/new-views-marry.md
@@ -1,0 +1,7 @@
+---
+'@kubricate/mono': minor
+'kubricate': patch
+'@kubricate/stacks': patch
+---
+
+Refactor Toolchain: Centralize Dual Output Build for both ESM and CJS with Mono Package

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "prepare": "turbo run @kubricate/mono#build --output-logs=errors-only",
-    "build": "turbo run build --filter=!./examples/*",
+    "build": "turbo run build --filter=!./tools/template --filter=!./examples/*",
     "all": "npm run build && npm run lint:check && npm run test",
     "dev": "turbo run dev --filter=!./tools/template --filter=!./examples/*",
     "lint:check": "turbo lint:check check-types && npm run format",

--- a/packages/kubricate/package.json
+++ b/packages/kubricate/package.json
@@ -14,12 +14,9 @@
     }
   },
   "scripts": {
-    "dev": "tsc -w",
+    "dev": "mono dev",
     "start": "mono start",
-    "build": "npm run build-esm && npm run  build-cjs && npm run build-annotate",
-    "build-esm": "tsc",
-    "build-cjs": "babel dist/esm --plugins @babel/transform-export-namespace-from --plugins @babel/transform-modules-commonjs --out-dir dist/cjs --source-maps",
-    "build-annotate": "babel dist --plugins annotate-pure-calls --out-dir dist --source-maps",
+    "build": "mono build",
     "test": "mono test",
     "test:watch": "mono test:watch",
     "lint:check": "mono lint:check",

--- a/packages/kubricate/package.json
+++ b/packages/kubricate/package.json
@@ -31,12 +31,7 @@
     "@kubricate/config-eslint": "workspace:*",
     "@kubricate/config-typescript": "workspace:*",
     "@kubricate/config-vitest": "workspace:*",
-    "@babel/cli": "^7.24.5",
-    "@babel/core": "^7.24.5",
-    "@babel/plugin-transform-export-namespace-from": "^7.24.1",
-    "@babel/plugin-transform-modules-commonjs": "^7.24.1",
-    "@types/lodash.merge": "^4.6.9",
-    "babel-plugin-annotate-pure-calls": "^0.4.0"
+    "@types/lodash.merge": "^4.6.9"
   },
   "repository": {
     "type": "git",

--- a/packages/stacks/package.json
+++ b/packages/stacks/package.json
@@ -13,11 +13,9 @@
     }
   },
   "scripts": {
-    "dev": "tsc -w",
-    "build": "npm run build-esm && npm run  build-cjs && npm run build-annotate",
-    "build-esm": "tsc",
-    "build-cjs": "babel dist/esm --plugins @babel/transform-export-namespace-from --plugins @babel/transform-modules-commonjs --out-dir dist/cjs --source-maps",
-    "build-annotate": "babel dist --plugins annotate-pure-calls --out-dir dist --source-maps",
+    "dev": "mono dev",
+    "start": "mono start",
+    "build": "mono build",
     "test": "mono test",
     "test:watch": "mono test:watch",
     "lint:check": "mono lint:check",
@@ -25,16 +23,10 @@
     "check-types": "mono check-types"
   },
   "devDependencies": {
-    "@babel/cli": "^7.24.5",
-    "@babel/core": "^7.24.5",
-    "@babel/plugin-transform-export-namespace-from": "^7.24.1",
-    "@babel/plugin-transform-modules-commonjs": "^7.24.1",
     "@kubricate/config-eslint": "workspace:*",
     "@kubricate/config-typescript": "workspace:*",
     "@kubricate/config-vitest": "workspace:*",
-    "@kubricate/mono": "workspace:*",
-    "@types/lodash.merge": "^4.6.9",
-    "babel-plugin-annotate-pure-calls": "^0.4.0"
+    "@kubricate/mono": "workspace:*"
   },
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 2.28.1
       '@vitest/coverage-istanbul':
         specifier: ^3.0.9
-        version: 3.0.9(vitest@3.0.9(@types/node@22.13.11)(@vitest/ui@3.0.9)(jsdom@26.0.0)(tsx@4.19.1)(yaml@2.7.0))
+        version: 3.0.9(vitest@3.0.9)
       esbuild:
         specifier: ^0.25.1
         version: 0.25.1
@@ -78,7 +78,7 @@ importers:
         version: link:../config-typescript
       '@vitest/coverage-istanbul':
         specifier: ^3.0.9
-        version: 3.0.9(vitest@3.0.9(@types/node@22.13.11)(@vitest/ui@3.0.9)(jsdom@26.0.0)(tsx@4.19.1)(yaml@2.7.0))
+        version: 3.0.9(vitest@3.0.9)
       '@vitest/ui':
         specifier: 3.0.9
         version: 3.0.9(vitest@3.0.9)
@@ -132,18 +132,6 @@ importers:
         specifier: ^4.6.2
         version: 4.6.2
     devDependencies:
-      '@babel/cli':
-        specifier: ^7.24.5
-        version: 7.27.0(@babel/core@7.26.10)
-      '@babel/core':
-        specifier: ^7.24.5
-        version: 7.26.10
-      '@babel/plugin-transform-export-namespace-from':
-        specifier: ^7.24.1
-        version: 7.25.9(@babel/core@7.26.10)
-      '@babel/plugin-transform-modules-commonjs':
-        specifier: ^7.24.1
-        version: 7.26.3(@babel/core@7.26.10)
       '@kubricate/config-eslint':
         specifier: workspace:*
         version: link:../../configs/config-eslint
@@ -159,9 +147,6 @@ importers:
       '@types/lodash.merge':
         specifier: ^4.6.9
         version: 4.6.9
-      babel-plugin-annotate-pure-calls:
-        specifier: ^0.4.0
-        version: 0.4.0(@babel/core@7.26.10)
 
   packages/stacks:
     dependencies:
@@ -175,18 +160,6 @@ importers:
         specifier: workspace:*
         version: link:../kubricate
     devDependencies:
-      '@babel/cli':
-        specifier: ^7.24.5
-        version: 7.27.0(@babel/core@7.26.10)
-      '@babel/core':
-        specifier: ^7.24.5
-        version: 7.26.10
-      '@babel/plugin-transform-export-namespace-from':
-        specifier: ^7.24.1
-        version: 7.25.9(@babel/core@7.26.10)
-      '@babel/plugin-transform-modules-commonjs':
-        specifier: ^7.24.1
-        version: 7.26.3(@babel/core@7.26.10)
       '@kubricate/config-eslint':
         specifier: workspace:*
         version: link:../../configs/config-eslint
@@ -199,15 +172,24 @@ importers:
       '@kubricate/mono':
         specifier: workspace:*
         version: link:../../tools/mono
-      '@types/lodash.merge':
-        specifier: ^4.6.9
-        version: 4.6.9
-      babel-plugin-annotate-pure-calls:
-        specifier: ^0.4.0
-        version: 0.4.0(@babel/core@7.26.10)
 
   tools/mono:
     dependencies:
+      '@babel/cli':
+        specifier: '>=7.24.5 <8.0.0'
+        version: 7.27.0(@babel/core@7.26.10)
+      '@babel/core':
+        specifier: '>=7.24.5 <8.0.0'
+        version: 7.26.10
+      '@babel/plugin-transform-export-namespace-from':
+        specifier: '>=7.24.1 <8.0.0'
+        version: 7.25.9(@babel/core@7.26.10)
+      '@babel/plugin-transform-modules-commonjs':
+        specifier: '>=7.24.1 <8.0.0'
+        version: 7.26.3(@babel/core@7.26.10)
+      babel-plugin-annotate-pure-calls:
+        specifier: '>=0.4.0 <1.0.0'
+        version: 0.4.0(@babel/core@7.26.10)
       execa:
         specifier: ^9.5.2
         version: 9.5.2
@@ -4201,7 +4183,7 @@ snapshots:
       '@typescript-eslint/types': 8.26.0
       eslint-visitor-keys: 4.2.0
 
-  '@vitest/coverage-istanbul@3.0.9(vitest@3.0.9(@types/node@22.13.11)(@vitest/ui@3.0.9)(jsdom@26.0.0)(tsx@4.19.1)(yaml@2.7.0))':
+  '@vitest/coverage-istanbul@3.0.9(vitest@3.0.9)':
     dependencies:
       '@istanbuljs/schema': 0.1.3
       debug: 4.4.0

--- a/tools/mono/package.json
+++ b/tools/mono/package.json
@@ -15,6 +15,13 @@
     "lint:fix": "eslint --fix ./src",
     "check-types": "tsc --noEmit"
   },
+  "peerDependencies": {
+    "@babel/cli": ">=7.24.5 <8.0.0",
+    "@babel/core": ">=7.24.5 <8.0.0",
+    "@babel/plugin-transform-export-namespace-from": ">=7.24.1 <8.0.0",
+    "@babel/plugin-transform-modules-commonjs": ">=7.24.1 <8.0.0",
+    "babel-plugin-annotate-pure-calls": ">=0.4.0 <1.0.0"
+  },
   "dependencies": {
     "execa": "^9.5.2"
   },

--- a/tools/mono/src/cli.ts
+++ b/tools/mono/src/cli.ts
@@ -27,6 +27,7 @@ const scripts: MonoScripts = {
 
 (async () => {
   for (const command of processArgs(process.argv[2], scripts)) {
+    console.log(`${command.join(' ')}`);
     await runCommand(command, {
       preferLocal: true,
     });

--- a/tools/mono/src/cli.ts
+++ b/tools/mono/src/cli.ts
@@ -1,15 +1,28 @@
 import { type MonoScripts, processArgs, runCommand } from './libs.js';
 
+const binName = 'mono';
+
 // prettier-ignore
 const scripts: MonoScripts = {
+  // Lint Scripts
   'lint:check': 'eslint src',
   'lint:fix': 'eslint src --fix',
+
+  // Test Scripts
   'test': 'vitest run',
   'test:watch': 'vitest watch',
-  'build': 'esbuild ./src/index.ts --bundle --minify --platform=node --outfile=dist/index.js',
-  'dev': 'tsx watch ./src/index.ts',
-  'start': 'tsx ./src/index.ts',
+
+  // Build in order: ESM, CJS, Annotate for support dual package both ESM and CJS
+  'build': [`${binName} build-esm`, `${binName} build-cjs`, `${binName} build-annotate`],
+  'build-esm': 'tsc',
+  'build-cjs': 'babel dist/esm --plugins @babel/transform-export-namespace-from --plugins @babel/transform-modules-commonjs --out-dir dist/cjs --source-maps',
+  'build-annotate': 'babel dist --plugins annotate-pure-calls --out-dir dist --source-maps',
+  // Compile TypeScript in watch mode
+  'dev': 'tsc -w',
+  // Check TypeScript types
   'check-types': 'tsc --noEmit',
+
+  'start': 'echo "No start script"',
 };
 
 (async () => {


### PR DESCRIPTION
This PR refactors the existing build toolchain by **centralizing control of dual output (ESM + CJS)** through a shared mono package utility.

### 🔄 What’s Changed:
- Introduced a centralized build utility under `tools/mono` for managing TypeScript + Babel builds across packages.
- Updated `build` and `dev` scripts to exclude irrelevant paths (`tools/template`, `examples`, etc.).
- Removed duplicated build logic from individual packages in favor of shared tooling.
- Cleaned up and simplified `package.json` scripts for consistency.

### ✅ Why:
- Improve maintainability by consolidating build logic in one place.
- Ensure consistency across all packages when building for both ESM and CJS outputs.
- Prepare the codebase for scaling with more packages and stacks in the future.