### PR TITLE
Fix CLI Entrypoint and Add Monorepo Maintenance Guide

### DIFF
--- a/.changeset/busy-hands-lead.md
+++ b/.changeset/busy-hands-lead.md
@@ -1,0 +1,5 @@
+---
+'kubricate': patch
+---
+
+Fix cli entrypoint

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,15 +2,8 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": true,
-  "fixed": [
-    [
-      "kubricate",
-      "@kubricate/core",
-      "@kubricate/stacks",
-      "@kubricate/toolkit"
-    ]
-  ],
-  "linked": [],
+  "fixed": [],
+  "linked": [["@kubricate/stacks", "@kubricate/core"]],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",

--- a/docs/monorepo-maintenance-guide.md
+++ b/docs/monorepo-maintenance-guide.md
@@ -1,0 +1,52 @@
+# 🧠 Monorepo Maintenance Guide
+
+This monorepo uses [Changesets](https://github.com/changesets/changesets) for **versioning**, **changelog generation**, and **releases**.
+
+---
+
+## 🧩 Package Structure
+
+- `@kubricate/core` — shared utilities and types
+- `@kubricate/stacks` — depends on `core`
+- `@kubricate/toolkit` — independent tools
+- `kubricate` — CLI tool (uses `core` only for setup config types)
+- Future packages:
+  - `@kubricate/env`, `@kubricate/secrets`, `@kubricate/azure-keyvault` → depend on `core`
+
+---
+
+## 🔄 Versioning Strategy
+
+We use **linked packages**, not fixed.
+
+### ✅ Linked
+We use linked versioning **only for packages that must stay in sync**, like:
+
+```json
+"linked": [["@kubricate/stacks", "@kubricate/core"]]
+```
+
+When one changes, the other is bumped to the same version.
+
+## ❌ Not Fixed
+
+We avoid fixed packages. This keeps unrelated packages (e.g. CLI, toolkit, env) from being needlessly version bumped.
+
+## 🛠 Making a Change
+1. Run pnpm changeset
+	Follow the prompt to select packages and write a summary.
+2. Commit your changes including the .changeset file.
+3. CI will:
+   - Bump versions appropriately
+   - Generate changelogs
+   - Publish packages on merge (if configured)
+
+## 📦 Guidelines
+ - If a package uses @kubricate/core at runtime, declare it as a dependency.
+ - If a package uses only types from core, declare it as a devDependency to avoid unnecessary releases.
+ - Avoid changing version numbers manually — let Changesets handle it.
+
+## 🔍 Need Help?
+ - Refer to [.changeset/config.json](../.changeset/config.json) for versioning rules.
+ - Read the [Changesets docs](https://github.com/changesets/changesets/blob/main/docs/config-file-options.md) for full options.
+

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "turbo run test",
     "test:watch": "turbo run test:watch",
     "test:coverage-report": "turbo run view-report",
-    "release": "npm run all && changeset version && changeset publish"
+    "release": "npm run all && changeset version && changeset publish",
+    "graph": "npx nx graph"
   },
   "engines": {
     "node": ">=22"

--- a/packages/kubricate/bin.mjs
+++ b/packages/kubricate/bin.mjs
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+await import('./dist/esm/cli.js')

--- a/packages/kubricate/package.json
+++ b/packages/kubricate/package.json
@@ -13,9 +13,10 @@
     }
   },
   "bin": {
-    "kubricate": "dist/cli.js"
+    "kubricate": "bin.mjs"
   },
   "files": [
+    "bin.mjs",
     "dist",
     "src",
     "package.json",
@@ -24,9 +25,7 @@
   "scripts": {
     "dev": "mono dev",
     "start": "mono start",
-    "build": "npm run build:cli && npm run build:library",
-    "build:cli": "mono build:cli",
-    "build:library": "mono build",
+    "build": "mono build",
     "test": "mono test",
     "test:watch": "mono test:watch",
     "lint:check": "mono lint:check",


### PR DESCRIPTION
This PR resolves the incorrect CLI entrypoint configuration for the `kubricate` package and introduces documentation for maintaining the monorepo.

### 📦 What’s Included:

#### 1. CLI Entrypoint Fix
- Added `bin.mjs` file to serve as the proper CLI entrypoint for the `kubricate` package
- Updated `package.json` to reference the new `bin.mjs` under the `bin` field

#### 2. Changeset & Versioning
- Added a changeset to trigger a patch release for `kubricate` with the CLI fix
- Updated `changeset/config.json` to clean up previous entries

#### 3. Documentation
- Added `docs/monorepo-maintenance-guide.md` with instructions on maintaining and managing the Kubricate monorepo

### 🧩 Summary
This update ensures the CLI entrypoint works correctly and improves the developer experience by documenting the monorepo maintenance workflow. It also sets up a patch release to reflect the fix.