### PR TITLE
Fix CLI Config Loading and Improve Error Messages in `generate` Command

### DIFF
--- a/.changeset/solid-mice-drum.md
+++ b/.changeset/solid-mice-drum.md
@@ -1,0 +1,5 @@
+---
+'kubricate': patch
+---
+
+Fix CLI load config and improve error message

--- a/packages/kubricate/src/commands/generate.ts
+++ b/packages/kubricate/src/commands/generate.ts
@@ -11,15 +11,13 @@ export interface GenerateCommandOptions extends LoadConfigOptions {
 }
 
 export class GenerateCommand {
-  constructor(private options: GenerateCommandOptions) { }
+  constructor(private options: GenerateCommandOptions) {}
 
   async execute() {
     console.log(c.bold('Executing: Generating Kubricate stacks for Kubernetes...'));
 
     if (!this.options.config) {
-      console.log(
-        `${MARK_INFO} No config file provided. Falling back to default: '${getMatchConfigFile()}'`
-      );
+      console.log(`${MARK_INFO} No config file provided. Falling back to default: '${getMatchConfigFile()}'`);
     } else {
       console.log(`${MARK_INFO} Using config file: ${this.options.config}`);
     }
@@ -29,7 +27,9 @@ export class GenerateCommand {
     const config = await getConfig(this.options);
     if (!config) {
       console.log(c.red`${MARK_ERROR} No config file found matching '${getMatchConfigFile()}'\n`);
-      console.log(c.red`${MARK_ERROR} Please ensure a config file exists in the root directory:\n   ${this.options.root}\n`);
+      console.log(
+        c.red`${MARK_ERROR} Please ensure a config file exists in the root directory:\n   ${this.options.root}\n`
+      );
       console.log(c.red`${MARK_ERROR} If your config is located elsewhere, specify it using:\n   --root <dir>\n`);
 
       console.log(c.red`${MARK_ERROR} Or specify a config file using:\n   --config <file>\n`);

--- a/packages/kubricate/src/commands/generate.ts
+++ b/packages/kubricate/src/commands/generate.ts
@@ -1,7 +1,7 @@
 import c from 'ansis';
 import { MARK_CHECK, MARK_ERROR, MARK_INFO, MARK_NODE } from '../constant.js';
 import { getClassName } from '../utils.js';
-import { getConfig, LoadConfigOptions } from '../load-config.js';
+import { getConfig, getMatchConfigFile, LoadConfigOptions } from '../load-config.js';
 import { stringify as yamlStringify } from 'yaml';
 import fs from 'node:fs/promises';
 import path from 'node:path';
@@ -14,11 +14,11 @@ export class GenerateCommand {
   constructor(private options: GenerateCommandOptions) { }
 
   async execute() {
-    console.log(c.bold('Executing: Generating Kubernetes stacks with Kubricate...'));
+    console.log(c.bold('Executing: Generating Kubricate stacks for Kubernetes...'));
 
     if (!this.options.config) {
       console.log(
-        `${MARK_INFO} No config file provided. Falling back to default: 'kubricate.config.{js,ts,mjs,cjs}'`
+        `${MARK_INFO} No config file provided. Falling back to default: '${getMatchConfigFile()}'`
       );
     } else {
       console.log(`${MARK_INFO} Using config file: ${this.options.config}`);
@@ -28,7 +28,7 @@ export class GenerateCommand {
 
     const config = await getConfig(this.options);
     if (!config) {
-      console.log(c.red`${MARK_ERROR} No config file found matching 'kubricate.config.{js,ts,mjs,cjs}'\n`);
+      console.log(c.red`${MARK_ERROR} No config file found matching '${getMatchConfigFile()}'\n`);
       console.log(c.red`${MARK_ERROR} Please ensure a config file exists in the root directory:\n   ${this.options.root}\n`);
       console.log(c.red`${MARK_ERROR} If your config is located elsewhere, specify it using:\n   --root <dir>\n`);
 
@@ -50,7 +50,7 @@ export class GenerateCommand {
 
     console.log('');
     console.log('---------------------');
-    console.log(c.bold`Generating stacks...`);
+    console.log(c.bold`Generating Kubricate stacks...`);
     console.log('---------------------');
 
     let output = '';

--- a/packages/kubricate/src/commands/generate.ts
+++ b/packages/kubricate/src/commands/generate.ts
@@ -65,7 +65,7 @@ export class GenerateCommand {
     }
     console.log(c.green`${MARK_CHECK} All stacks generated successfully`);
 
-    const outputPath = path.join(this.options.outDir, 'stacks.yml');
+    const outputPath = path.join(this.options.root, this.options.outDir, 'stacks.yml');
     await fs.mkdir(this.options.outDir, { recursive: true });
     await fs.writeFile(outputPath, output);
 

--- a/packages/kubricate/src/commands/generate.ts
+++ b/packages/kubricate/src/commands/generate.ts
@@ -14,11 +14,11 @@ export class GenerateCommand {
   constructor(private options: GenerateCommandOptions) { }
 
   async execute() {
-    console.log(c.bold('Executing kubricate generates stacks...'));
+    console.log(c.bold('Executing: Generating Kubernetes stacks with Kubricate...'));
 
     if (!this.options.config) {
       console.log(
-        `${MARK_INFO} No config file provided, using default config file which is 'kubricate.config.{js,ts,mjs,cjs}'`
+        `${MARK_INFO} No config file provided. Falling back to default: 'kubricate.config.{js,ts,mjs,cjs}'`
       );
     } else {
       console.log(`${MARK_INFO} Using config file: ${this.options.config}`);
@@ -28,9 +28,12 @@ export class GenerateCommand {
 
     const config = await getConfig(this.options);
     if (!config) {
-      console.log(c.red`${MARK_ERROR} No config file found with matched pattern 'kubricate.config.{js,ts,mjs,cjs}'`);
-      console.log(c.red`${MARK_ERROR} Please make sure the config file in the root directory at ${this.options.root}`);
-      console.log(c.red`${MARK_ERROR} If the config is located is different root directory, please use '--root <dir>'`);
+      console.log(c.red`${MARK_ERROR} No config file found matching 'kubricate.config.{js,ts,mjs,cjs}'\n`);
+      console.log(c.red`${MARK_ERROR} Please ensure a config file exists in the root directory:\n   ${this.options.root}\n`);
+      console.log(c.red`${MARK_ERROR} If your config is located elsewhere, specify it using:\n   --root <dir>\n`);
+
+      console.log(c.red`${MARK_ERROR} Or specify a config file using:\n   --config <file>\n`);
+      console.log(c.red`${MARK_ERROR} Exiting...`);
       process.exit(1);
     }
     const stacksLength = Object.keys(config.stacks ?? {}).length;
@@ -45,6 +48,7 @@ export class GenerateCommand {
       console.log(c.blue`    ${MARK_NODE} ${name}: ${getClassName(stack)}`);
     }
 
+    console.log('');
     console.log('---------------------');
     console.log(c.bold`Generating stacks...`);
     console.log('---------------------');
@@ -52,12 +56,12 @@ export class GenerateCommand {
     let output = '';
 
     for (const [name, stack] of Object.entries(config.stacks)) {
-      console.log(c.blue`${MARK_NODE} Generating stack ${name}...`);
+      console.log(c.blue`${MARK_NODE} Generating stack: ${name}...`);
       for (const resource of stack.build()) {
         output += yamlStringify(resource);
         output += '---\n';
       }
-      console.log(c.green`${MARK_CHECK} Stack ${name} generated successfully`);
+      console.log(c.green`${MARK_CHECK} Successfully generated stack: ${name}`);
     }
     console.log(c.green`${MARK_CHECK} All stacks generated successfully`);
 
@@ -65,7 +69,8 @@ export class GenerateCommand {
     await fs.mkdir(this.options.outDir, { recursive: true });
     await fs.writeFile(outputPath, output);
 
-    console.log(`${MARK_INFO} Written stacks to '${path.resolve(outputPath)}'`);
+    console.log('');
+    console.log(`${MARK_INFO} YAML file successfully written to:\n   '${path.resolve(outputPath)}'\n`);
 
     console.info(c.green`${MARK_CHECK} Done!`);
   }

--- a/packages/kubricate/src/commands/generate.ts
+++ b/packages/kubricate/src/commands/generate.ts
@@ -11,7 +11,7 @@ export interface GenerateCommandOptions extends LoadConfigOptions {
 }
 
 export class GenerateCommand {
-  constructor(private options: GenerateCommandOptions) {}
+  constructor(private options: GenerateCommandOptions) { }
 
   async execute() {
     console.log(c.bold('Executing kubricate generates stacks...'));
@@ -27,6 +27,12 @@ export class GenerateCommand {
     console.log(`${MARK_INFO} Output directory: ${this.options.outDir}`);
 
     const config = await getConfig(this.options);
+    if (!config) {
+      console.log(c.red`${MARK_ERROR} No config file found with matched pattern 'kubricate.config.{js,ts,mjs,cjs}'`);
+      console.log(c.red`${MARK_ERROR} Please make sure the config file in the root directory at ${this.options.root}`);
+      console.log(c.red`${MARK_ERROR} If the config is located is different root directory, please use '--root <dir>'`);
+      process.exit(1);
+    }
     const stacksLength = Object.keys(config.stacks ?? {}).length;
 
     if (!config.stacks || stacksLength === 0) {

--- a/packages/kubricate/src/load-config.ts
+++ b/packages/kubricate/src/load-config.ts
@@ -1,5 +1,5 @@
 import { loadConfig } from 'unconfig';
-import { MARK_CHECK } from './constant.js';
+import { MARK_CHECK, MARK_ERROR, MARK_INFO } from './constant.js';
 import { KubricateConfig } from './config.js';
 import c from 'ansis';
 
@@ -8,7 +8,7 @@ export interface LoadConfigOptions {
   config?: string;
 }
 
-export async function getConfig(options: LoadConfigOptions): Promise<KubricateConfig> {
+export async function getConfig(options: LoadConfigOptions): Promise<KubricateConfig | undefined> {
   const result = await loadConfig<KubricateConfig>({
     cwd: options.root,
     sources: [

--- a/packages/kubricate/src/load-config.ts
+++ b/packages/kubricate/src/load-config.ts
@@ -8,14 +8,22 @@ export interface LoadConfigOptions {
   config?: string;
 }
 
+export const DEFAULT_CONFIG_NAME = 'kubricate.config';
+// Allow all JS/TS file extensions except JSON
+export const DEFAULT_CONFIG_EXTENSIONS = ['mts', 'cts', 'ts', 'mjs', 'cjs', 'js'];
+
+export function getMatchConfigFile(): string {
+  return `${DEFAULT_CONFIG_NAME}.{${DEFAULT_CONFIG_EXTENSIONS.join(',')}}`;
+}
+
 export async function getConfig(options: LoadConfigOptions): Promise<KubricateConfig | undefined> {
   const result = await loadConfig<KubricateConfig>({
     cwd: options.root,
     sources: [
       {
-        files: options.config || 'kubricate.config',
+        files: options.config || DEFAULT_CONFIG_NAME,
         // Allow all JS/TS file extensions except JSON
-        extensions: ['mts', 'cts', 'ts', 'mjs', 'cjs', 'js'],
+        extensions: DEFAULT_CONFIG_EXTENSIONS,
       },
     ],
     merge: false,


### PR DESCRIPTION
This PR improves the robustness of the `kubricate generate` command by fixing how the CLI loads config files and enhancing error message clarity.

### 📦 What’s Included:

#### 1. Fix Config Loading
- Fixed path resolution and validation logic for loading user-provided config files
- Ensures fallback behavior and clearer error stack when config is missing or invalid

#### 2. Enhanced Error Output
- Improved console output when config loading fails
- Added color and structure to error messages for better readability

### 🧩 Summary
This update enhances the user experience for the `generate` command by making config loading more reliable and delivering clearer, more helpful error messages during CLI execution.