### PR TITLE
Migrate All Packages to Use Native ESM Modules

### DIFF
--- a/.changeset/tired-news-pump.md
+++ b/.changeset/tired-news-pump.md
@@ -1,0 +1,11 @@
+---
+'@kubricate/config-typescript': patch
+'kubricate': patch
+'@kubricate/toolkit': patch
+'@kubricate/stacks': patch
+'@kubricate/template': patch
+'@kubricate/core': patch
+'@kubricate/mono': patch
+---
+
+Use ESM module for all projects

--- a/configs/config-typescript/dual.json
+++ b/configs/config-typescript/dual.json
@@ -6,6 +6,7 @@
     "module": "nodenext",
     "moduleDetection": "force",
     "moduleResolution": "nodenext",
+    "verbatimModuleSyntax": true,
 
     "lib": ["ESNext", "DOM"],
     "declaration": true,

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "devDependencies": {
     "@changesets/cli": "^2.28.1",
     "@vitest/coverage-istanbul": "^3.0.9",
-    "esbuild": "^0.25.1",
     "eslint": "^9.22.0",
     "prettier": "^3.5.3",
     "turbo": "^2.4.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,7 @@
   "name": "@kubricate/core",
   "description": "A TypeScript framework for building, managing, and compiling Kubernetes manifests with a structured, reusable, and Helm-compatible approach",
   "version": "0.6.0",
+  "type": "module",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/dts/index.d.ts",

--- a/packages/core/src/KubricateStack.ts
+++ b/packages/core/src/KubricateStack.ts
@@ -1,5 +1,5 @@
 import { KubricateController } from './KubricateController.js';
-import { FunctionLike, InferResourceBuilderFunction } from './types.js';
+import type { FunctionLike, InferResourceBuilderFunction } from './types.js';
 
 export abstract class KubricateStack<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/core/src/KubricateStack.ts
+++ b/packages/core/src/KubricateStack.ts
@@ -1,5 +1,5 @@
-import { KubricateController } from './KubricateController';
-import { FunctionLike, InferResourceBuilderFunction } from './types';
+import { KubricateController } from './KubricateController.js';
+import { FunctionLike, InferResourceBuilderFunction } from './types.js';
 
 export abstract class KubricateStack<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/kubricate/package.json
+++ b/packages/kubricate/package.json
@@ -1,6 +1,7 @@
 {
   "name": "kubricate",
   "version": "0.6.2",
+  "type": "module",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/dts/index.d.ts",

--- a/packages/kubricate/src/cli.ts
+++ b/packages/kubricate/src/cli.ts
@@ -2,7 +2,7 @@ import { cac } from 'cac';
 import c from 'ansis';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { GenerateCommand, GenerateCommandOptions } from './commands/generate.js';
+import { GenerateCommand, type GenerateCommandOptions } from './commands/generate.js';
 
 const pkg = {
   version: '0.0.0',

--- a/packages/kubricate/src/cli.ts
+++ b/packages/kubricate/src/cli.ts
@@ -1,4 +1,4 @@
-import cac from 'cac';
+import { cac } from 'cac';
 import c from 'ansis';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';

--- a/packages/kubricate/src/commands/generate.ts
+++ b/packages/kubricate/src/commands/generate.ts
@@ -1,7 +1,7 @@
 import c from 'ansis';
 import { MARK_CHECK, MARK_ERROR, MARK_INFO, MARK_NODE } from '../constant.js';
 import { getClassName } from '../utils.js';
-import { getConfig, getMatchConfigFile, LoadConfigOptions } from '../load-config.js';
+import { getConfig, getMatchConfigFile, type LoadConfigOptions } from '../load-config.js';
 import { stringify as yamlStringify } from 'yaml';
 import fs from 'node:fs/promises';
 import path from 'node:path';

--- a/packages/kubricate/src/load-config.ts
+++ b/packages/kubricate/src/load-config.ts
@@ -1,6 +1,6 @@
 import { loadConfig } from 'unconfig';
 import { MARK_CHECK } from './constant.js';
-import { KubricateConfig } from './config.js';
+import type { KubricateConfig } from './config.js';
 import c from 'ansis';
 
 export interface LoadConfigOptions {

--- a/packages/kubricate/src/load-config.ts
+++ b/packages/kubricate/src/load-config.ts
@@ -1,5 +1,5 @@
 import { loadConfig } from 'unconfig';
-import { MARK_CHECK, MARK_ERROR, MARK_INFO } from './constant.js';
+import { MARK_CHECK } from './constant.js';
 import { KubricateConfig } from './config.js';
 import c from 'ansis';
 

--- a/packages/stacks/package.json
+++ b/packages/stacks/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@kubricate/stacks",
   "version": "0.6.0",
+  "type": "module",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/dts/index.d.ts",

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@kubricate/toolkit",
   "version": "0.5.2",
+  "type": "module",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/dts/index.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@vitest/coverage-istanbul':
         specifier: ^3.0.9
         version: 3.0.9(vitest@3.0.9(@types/node@22.13.11)(@vitest/ui@3.0.9)(jiti@2.4.2)(jsdom@26.0.0)(tsx@4.19.3)(yaml@2.7.0))
-      esbuild:
-        specifier: ^0.25.1
-        version: 0.25.1
       eslint:
         specifier: ^9.22.0
         version: 9.22.0(jiti@2.4.2)
@@ -255,9 +252,6 @@ importers:
       '@types/node':
         specifier: ^22.13.9
         version: 22.13.11
-      esbuild:
-        specifier: ^0.25.1
-        version: 0.25.1
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1

--- a/tools/mono/package.json
+++ b/tools/mono/package.json
@@ -29,7 +29,6 @@
     "@kubricate/config-eslint": "workspace:*",
     "@kubricate/config-typescript": "workspace:*",
     "@types/node": "^22.13.9",
-    "picocolors": "^1.1.1",
-    "esbuild": "^0.25.1"
+    "picocolors": "^1.1.1"
   }
 }

--- a/tools/mono/src/cli.ts
+++ b/tools/mono/src/cli.ts
@@ -17,8 +17,6 @@ const scripts: MonoScripts = {
   'build-esm': 'tsc',
   'build-cjs': 'babel dist/esm --plugins @babel/transform-export-namespace-from --plugins @babel/transform-modules-commonjs --out-dir dist/cjs --source-maps',
   'build-annotate': 'babel dist --plugins annotate-pure-calls --out-dir dist --source-maps',
-  // Build CLI
-  'build:cli': 'esbuild ./src/cli.ts --bundle --minify --platform=node --outfile=dist/cli.js',
   // Compile TypeScript in watch mode
   'dev': 'tsc -w',
   // Check TypeScript types

--- a/tools/template/package.json
+++ b/tools/template/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@kubricate/template",
   "version": "0.0.0",
+  "type": "module",
   "private": true,
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",


### PR DESCRIPTION
This PR migrates all packages in the monorepo to use native **ESM (ECMAScript Modules)** by default, standardizing the module format and improving future compatibility.

### 📦 What’s Included:

#### Enable Native ESM
- Added `"type": "module"` to all `package.json` files
- Updated TypeScript config to support native ESM and `verbatimModuleSyntax`

### 🧩 Summary
Migrating to native ESM improves long-term support with modern tooling, aligns with the JavaScript ecosystem’s direction, and ensures consistency across all packages in the monorepo.