### PR TITLE
Fix Type Inference Issue with `createStack` Factory Function

### DIFF
--- a/.changeset/itchy-rockets-speak.md
+++ b/.changeset/itchy-rockets-speak.md
@@ -1,0 +1,9 @@
+---
+'kubricate': patch
+'@kubricate/toolkit': patch
+'@kubricate/stacks': patch
+'@kubricate/core': patch
+'@kubricate/env': patch
+---
+
+Fix Type inference when build with createStack factory helper function

--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@
 - 📦 Type-safe Kubernetes manifest generation with TypeScript
 - ♻️ Reusable, composable stack system
 - 🔐 Secrets injection via `SecretManager` and loaders (e.g., `.env`, process.env)
-- 📂 Structured output with Helm-compatible YAML
-- 🧪 Ready for testing and CI workflows
 
 ## Getting Started
 
@@ -118,8 +116,6 @@ Kubricate offers a type-safe developer experience for building Kubernetes manife
 - `@kubricate/stacks` – Official reusable stack definitions
 - `@kubricate/toolkit` – Utility functions for custom stack authors
 
----
-
 ## Version Compatibility
 
 Ensure the following packages are always on the same version when upgrading:
@@ -129,13 +125,9 @@ Ensure the following packages are always on the same version when upgrading:
 - `@kubricate/env`
 - `@kubricate/stacks`
 
----
-
 ## Documentation & Examples
 
 Explore the [`examples`](https://github.com/thaitype/kubricate/tree/main/examples) directory for real-world usage patterns and advanced features.
-
----
 
 ## Development
 
@@ -154,8 +146,6 @@ To run the examples run with
 ```sh
 pnpm --filter=@examples/with-custom-stack kubricate generate
 ```
-
----
 
 ## How to Publish
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,116 @@
-# Kubricate
+<p align="center">
+<a href="https://github.com/thaitype/kubricate"><img src="https://i.ibb.co/hJTg9vhs/kubricate-logo.png" alt="kubricate-logo" border="0" width="120" ></a>
+<h4 align="center" style="padding:0;margin-top:0;">Kubricate</h4>
+</p>
 
-[![Release](https://github.com/thaitype/kubricate/actions/workflows/test-and-build.yml/badge.svg)](https://github.com/thaitype/kubricate/actions/workflows/test-and-build.yml)
-
+<p align="center">
 A TypeScript framework for building, managing, and compiling Kubernetes resources with a structured, reusable, and Helm-compatible approach
+</p>
+
+
+<p align="center"><a href="https://github.com/thaitype/kubricate/actions/workflows/test-and-build.yml"><img src="https://github.com/thaitype/kubricate/actions/workflows/test-and-build.yml/badge.svg" alt="Build"></a>
+<a href="https://www.npmjs.com/package/kubricate"><img alt="NPM Version (with dist tag)" src="https://img.shields.io/npm/v/kubricate">
+ <a href="https://www.npmjs.com/package/kubricate"><img src="https://img.shields.io/npm/dt/kubricate" alt="npm download"></a></p>
+
 
 > Experimental: This project is still in the early stages of development and is not yet ready for production use.
 
+## Getting Started
+
+```bash
+npm install -D kubricate
+npm install @kubricate/core
+```
+
+In case you want kubernetes type in typescript, just simple install `kubernetes-models` package. this will help you to generate typescript types from kubernetes resources.
+
+```bash
+npm install -D kubernetes-models
+```
+
+then, create a kubricate stack, what is kubricate stacks, help you to manage your kubernetes resources, and make it easy to deploy and manage your kubernetes resources.
+
+this example show how to create namespace in kubricate
+
+```ts
+// File: src/my-stack.ts
+import { createStack, ResourceComposer } from '@kubricate/core';
+import { Namespace } from 'kubernetes-models/v1';
+
+interface MyInput {
+  name: string;
+}
+
+const MyStack = createStack('MyStack', (data: MyInput) => {
+  return new ResourceComposer().addClass({
+    id: 'namespace',
+    type: Namespace,
+    config: {
+      metadata: { name: data.name },
+    },
+  });
+});
+
+export const myStack = MyStack.from({
+  name: 'my-namespace',
+});
+```
+then you can import into the `kubricate.config.ts` file, 
+which you should place the file in the root of your project. 
+
+```ts
+import { defineConfig } from 'kubricate';
+import { myStack } from './src/MyStack';
+
+export default defineConfig({
+  stacks: {
+    myStack,
+  },
+});
+```
+
+then you can run the kubricate command to generate the kubernetes resources.
+
+```sh
+npx kubricate generate
+```
+
+this will generate the kubernetes resources in the `.kubricate` folder. the log will look like this:
+
+```sh
+✔ YAML file successfully written to:
+  ~/with-custom-stack/.kubricate/stacks.yml
+```
+
+see the full example code: [with-custom-stack](https://github.com/thaitype/kubricate/tree/main/examples/with-custom-stack)
+
+try it you will see how good it is to use kubricate, it provide type-safety and easy to use, and you can use it with your existing kubernetes resources, and also override the resource with type safety, and also has secretManager to manage your secret from your target source (we called loader) .e.g. EnvLoader that load from `.env` or env var and bring your secret to the kubernetes resources and injecting into manifest via secret ref without exposing the secret in the manifest. 
+
+## Features
+...
+
+## Packages
+- kubricate - main cli, and handle config, manipulate with kubricate stacks, and generate kubernetes resources
+- @kubricate/core - core framework library for kubricate, and provide the core functionality for kubricate stacks
+- @kubricate/env - EnvLoader that can load from `.env` or env var and bring your secret to the kubernetes resources and injecting into manifest via secret ref without exposing the secret in the manifest.
+- @kubricate/stacks - Out of the box stacks that can be used with kubricate, and also provide the core functionality for kubricate stacks
+- @kubricate/toolkit - a set of tools that can be used with kubricate
+
+## How to Upgrade
+
+make sure you using the same version of kubricate, here is the list of packages, that need to strict together for easy upgrade:
+- kubricate
+- @kubricate/core
+- @kubricate/env
+- @kubricate/stacks
+
 ## Usages
 
-See in the [examples](./examples) folder.
+See in the [examples](https://github.com/thaitype/kubricate/tree/main/examples) folder.
+
+## Documentation
+
+See in the [examples](https://github.com/thaitype/kubricate/tree/main/examples) folder.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,36 @@
 <p align="center">
-<a href="https://github.com/thaitype/kubricate"><img src="https://i.ibb.co/hJTg9vhs/kubricate-logo.png" alt="kubricate-logo" border="0" width="120" ></a>
-<h4 align="center" style="padding:0;margin-top:0;">Kubricate</h4>
+  <a href="https://github.com/thaitype/kubricate">
+    <img src="https://i.ibb.co/hJTg9vhs/kubricate-logo.png" alt="kubricate-logo" width="120" />
+  </a>
+</p>
+
+<h2 align="center">Kubricate</h2>
+
+<p align="center">
+  A TypeScript framework for building, managing, and compiling Kubernetes resources with a structured, reusable, and Helm-compatible approach.
 </p>
 
 <p align="center">
-A TypeScript framework for building, managing, and compiling Kubernetes resources with a structured, reusable, and Helm-compatible approach
+  <a href="https://github.com/thaitype/kubricate/actions/workflows/test-and-build.yml">
+    <img src="https://github.com/thaitype/kubricate/actions/workflows/test-and-build.yml/badge.svg" alt="Build">
+  </a>
+  <a href="https://www.npmjs.com/package/kubricate">
+    <img alt="NPM Version" src="https://img.shields.io/npm/v/kubricate">
+  </a>
+  <a href="https://www.npmjs.com/package/kubricate">
+    <img src="https://img.shields.io/npm/dt/kubricate" alt="npm downloads">
+  </a>
 </p>
 
+> ⚠️ Experimental: This project is still in early development and not ready for production use.
 
-<p align="center"><a href="https://github.com/thaitype/kubricate/actions/workflows/test-and-build.yml"><img src="https://github.com/thaitype/kubricate/actions/workflows/test-and-build.yml/badge.svg" alt="Build"></a>
-<a href="https://www.npmjs.com/package/kubricate"><img alt="NPM Version (with dist tag)" src="https://img.shields.io/npm/v/kubricate">
- <a href="https://www.npmjs.com/package/kubricate"><img src="https://img.shields.io/npm/dt/kubricate" alt="npm download"></a></p>
+## Features
 
-
-> Experimental: This project is still in the early stages of development and is not yet ready for production use.
+- 📦 Type-safe Kubernetes manifest generation with TypeScript
+- ♻️ Reusable, composable stack system
+- 🔐 Secrets injection via `SecretManager` and loaders (e.g., `.env`, process.env)
+- 📂 Structured output with Helm-compatible YAML
+- 🧪 Ready for testing and CI workflows
 
 ## Getting Started
 
@@ -22,41 +39,46 @@ npm install -D kubricate
 npm install @kubricate/core
 ```
 
-In case you want kubernetes type in typescript, just simple install `kubernetes-models` package. this will help you to generate typescript types from kubernetes resources.
+If you want Kubernetes resource types in TypeScript, install `kubernetes-models`. It helps generate fully-typed resource objects.
 
 ```bash
 npm install -D kubernetes-models
 ```
 
-then, create a kubricate stack, what is kubricate stacks, help you to manage your kubernetes resources, and make it easy to deploy and manage your kubernetes resources.
+Then, create your first Kubricate Stack. Kubricate Stacks help you define, reuse, and manage Kubernetes resources in a clean, declarative way.
 
-this example show how to create namespace in kubricate
+### 🧱 Example: Creating a Namespace Stack
 
 ```ts
 // File: src/my-stack.ts
 import { createStack, ResourceComposer } from '@kubricate/core';
 import { Namespace } from 'kubernetes-models/v1';
 
+// Step 1: declare data schema
 interface MyInput {
   name: string;
 }
 
-const MyStack = createStack('MyStack', (data: MyInput) => {
-  return new ResourceComposer().addClass({
+// Step 2: define stack shape for reusable work
+const MyStack = createStack('MyStack', (data: MyInput) =>
+  new ResourceComposer().addClass({
     id: 'namespace',
     type: Namespace,
     config: {
       metadata: { name: data.name },
     },
-  });
-});
+  })
+);
 
-export const myStack = MyStack.from({
+// Usage: configure the stack with your own input
+envexport const myStack = MyStack.from({
   name: 'my-namespace',
 });
 ```
-then you can import into the `kubricate.config.ts` file, 
-which you should place the file in the root of your project. 
+
+### ⚙️ Configure with `kubricate.config.ts`
+
+Create a `kubricate.config.ts` file at the root of your project:
 
 ```ts
 import { defineConfig } from 'kubricate';
@@ -69,60 +91,78 @@ export default defineConfig({
 });
 ```
 
-then you can run the kubricate command to generate the kubernetes resources.
+### 🚀 Generate Kubernetes Resources
 
-```sh
+```bash
 npx kubricate generate
 ```
 
-this will generate the kubernetes resources in the `.kubricate` folder. the log will look like this:
+This will generate Kubernetes YAML files in the `.kubricate` folder:
 
-```sh
+```bash
 ✔ YAML file successfully written to:
   ~/with-custom-stack/.kubricate/stacks.yml
 ```
 
-see the full example code: [with-custom-stack](https://github.com/thaitype/kubricate/tree/main/examples/with-custom-stack)
+See the full working example: [`with-custom-stack`](https://github.com/thaitype/kubricate/tree/main/examples/with-custom-stack)
 
-try it you will see how good it is to use kubricate, it provide type-safety and easy to use, and you can use it with your existing kubernetes resources, and also override the resource with type safety, and also has secretManager to manage your secret from your target source (we called loader) .e.g. EnvLoader that load from `.env` or env var and bring your secret to the kubernetes resources and injecting into manifest via secret ref without exposing the secret in the manifest. 
+Kubricate offers a type-safe developer experience for building Kubernetes manifests. It works with your existing resources, supports secret injection through loaders like `EnvLoader`, and prevents exposing secrets in YAML.
 
-## Features
-...
+---
 
 ## Packages
-- kubricate - main cli, and handle config, manipulate with kubricate stacks, and generate kubernetes resources
-- @kubricate/core - core framework library for kubricate, and provide the core functionality for kubricate stacks
-- @kubricate/env - EnvLoader that can load from `.env` or env var and bring your secret to the kubernetes resources and injecting into manifest via secret ref without exposing the secret in the manifest.
-- @kubricate/stacks - Out of the box stacks that can be used with kubricate, and also provide the core functionality for kubricate stacks
-- @kubricate/toolkit - a set of tools that can be used with kubricate
 
-## How to Upgrade
+- `kubricate` – CLI for configuration and manifest generation
+- `@kubricate/core` – Core framework for creating and managing stacks
+- `@kubricate/env` – Secret loader for `.env` and environment variables
+- `@kubricate/stacks` – Official reusable stack definitions
+- `@kubricate/toolkit` – Utility functions for custom stack authors
 
-make sure you using the same version of kubricate, here is the list of packages, that need to strict together for easy upgrade:
-- kubricate
-- @kubricate/core
-- @kubricate/env
-- @kubricate/stacks
+---
 
-## Usages
+## Version Compatibility
 
-See in the [examples](https://github.com/thaitype/kubricate/tree/main/examples) folder.
+Ensure the following packages are always on the same version when upgrading:
 
-## Documentation
+- `kubricate`
+- `@kubricate/core`
+- `@kubricate/env`
+- `@kubricate/stacks`
 
-See in the [examples](https://github.com/thaitype/kubricate/tree/main/examples) folder.
+---
+
+## Documentation & Examples
+
+Explore the [`examples`](https://github.com/thaitype/kubricate/tree/main/examples) directory for real-world usage patterns and advanced features.
+
+---
 
 ## Development
 
-This manual for development of Kubricate package.
+To develop Kubricate:
 
-Before start, `pnpm install && pnpm dev` for install dependencies and start build typescript in watch mode.
+```bash
+pnpm install
+pnpm build
+pnpm dev
+```
 
-## How to publish
+This installs dependencies and starts TypeScript in watch mode.
 
-1. pnpm changeset -> select the package you want to publish
-2. git push 
-3. waiting for github actions run and create a release PR
-4. review on PR 
-5. approve pr
-6. it will auto publish to npm
+To run the examples run with
+
+```sh
+pnpm --filter=@examples/with-custom-stack kubricate generate
+```
+
+---
+
+## How to Publish
+
+1. Run `pnpm changeset` and select the packages to version
+2. Commit and push the changes
+3. GitHub Actions will open a release PR
+4. Review and approve the PR
+5. The packages will be published to NPM automatically
+```
+

--- a/examples/with-custom-stack/eslint.config.mjs
+++ b/examples/with-custom-stack/eslint.config.mjs
@@ -1,0 +1,4 @@
+import { config } from "@kubricate/config-eslint/base";
+
+/** @type {import("eslint").Linter.Config} */
+export default config;

--- a/examples/with-custom-stack/kubricate.config.ts
+++ b/examples/with-custom-stack/kubricate.config.ts
@@ -1,8 +1,8 @@
 import { defineConfig } from 'kubricate';
-import { myStack } from './src/MyStack';
+// import { myStack } from './src/MyStack';
 
 export default defineConfig({
   stacks: {
-    myStack,
+    // myStack,
   },
 });

--- a/examples/with-custom-stack/kubricate.config.ts
+++ b/examples/with-custom-stack/kubricate.config.ts
@@ -1,8 +1,8 @@
 import { defineConfig } from 'kubricate';
-// import { myStack } from './src/MyStack';
+import { myStack } from './src/MyStack';
 
 export default defineConfig({
   stacks: {
-    // myStack,
+    myStack,
   },
 });

--- a/examples/with-custom-stack/package.json
+++ b/examples/with-custom-stack/package.json
@@ -13,7 +13,10 @@
     "README.md"
   ],
   "scripts": {
-    "kubricate": "kubricate"
+    "kubricate": "kubricate",
+    "lint:check": "mono lint:check",
+    "lint:fix": "mono lint:fix",
+    "check-types": "mono check-types"
   },
   "peerDependencies": {
     "@kubernetes-models/base": ">=5.0.1 <6.0.0"

--- a/examples/with-custom-stack/src/MyStack.ts
+++ b/examples/with-custom-stack/src/MyStack.ts
@@ -1,21 +1,20 @@
-// import { createStack, ResourceComposer } from '@kubricate/core';
-// import { Namespace } from 'kubernetes-models/v1';
+import { createStack, ResourceComposer } from '@kubricate/core';
+import { Namespace } from 'kubernetes-models/v1';
 
-// interface MyInput {
-//   name: string;
-// }
+interface MyInput {
+  name: string;
+}
 
-// export const MyStack = createStack('MyStack', (data: MyInput) => {
-//   // Dosomething for your data, e.g. Validate the input data
-//   return new ResourceComposer().addClass({
-//     id: 'namespace',
-//     type: Namespace,
-//     config: {
-//       metadata: { name: data.name },
-//     },
-//   });
-// });
+const MyStack = createStack('MyStack', (data: MyInput) => {
+  return new ResourceComposer().addClass({
+    id: 'namespace',
+    type: Namespace,
+    config: {
+      metadata: { name: data.name },
+    },
+  });
+});
 
-// export const myStack = MyStack.from({
-//   name: 'my-namespace',
-// });
+export const myStack = MyStack.from({
+  name: 'my-namespace',
+});

--- a/examples/with-custom-stack/src/MyStack.ts
+++ b/examples/with-custom-stack/src/MyStack.ts
@@ -1,21 +1,21 @@
-import { createStack, ResourceComposer } from '@kubricate/core';
-import { Namespace } from 'kubernetes-models/v1';
+// import { createStack, ResourceComposer } from '@kubricate/core';
+// import { Namespace } from 'kubernetes-models/v1';
 
-interface MyInput {
-  name: string;
-}
+// interface MyInput {
+//   name: string;
+// }
 
-const MyStack = createStack('MyStack', (data: MyInput) => {
-  // Dosomething for your data, e.g. Validate the input data
-  return new ResourceComposer().addClass({
-    id: 'namespace',
-    type: Namespace,
-    config: {
-      metadata: { name: data.name },
-    },
-  });
-});
+// export const MyStack = createStack('MyStack', (data: MyInput) => {
+//   // Dosomething for your data, e.g. Validate the input data
+//   return new ResourceComposer().addClass({
+//     id: 'namespace',
+//     type: Namespace,
+//     config: {
+//       metadata: { name: data.name },
+//     },
+//   });
+// });
 
-export const myStack = MyStack.from({
-  name: 'my-namespace',
-});
+// export const myStack = MyStack.from({
+//   name: 'my-namespace',
+// });

--- a/examples/with-custom-stack/tsconfig.json
+++ b/examples/with-custom-stack/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@kubricate/config-typescript/base.json",
+  "compilerOptions": {
+    "outDir": "dist/esm",
+    "declarationDir": "dist/dts",
+  },
+  "exclude": ["node_modules", "*.config.ts", "dist"]
+}

--- a/examples/with-secrets/eslint.config.mjs
+++ b/examples/with-secrets/eslint.config.mjs
@@ -1,0 +1,4 @@
+import { config } from "@kubricate/config-eslint/base";
+
+/** @type {import("eslint").Linter.Config} */
+export default config;

--- a/examples/with-secrets/package.json
+++ b/examples/with-secrets/package.json
@@ -13,7 +13,10 @@
     "README.md"
   ],
   "scripts": {
-    "kubricate": "kubricate"
+    "kubricate": "kubricate",
+    "lint:check": "mono lint:check",
+    "lint:fix": "mono lint:fix",
+    "check-types": "mono check-types"
   },
   "peerDependencies": {
     "@kubernetes-models/base": ">=5.0.1 <6.0.0"

--- a/examples/with-secrets/src/config.ts
+++ b/examples/with-secrets/src/config.ts
@@ -1,6 +1,5 @@
 import { SecretManager, KubernetesSecretProvider } from '@kubricate/core';
 import { EnvLoader } from '@kubricate/env';
-import { AppStack } from './stacks/AppStack';
 
 export const config = {
   namespace: 'my-namespace',

--- a/examples/with-secrets/src/stacks/AppStack.ts
+++ b/examples/with-secrets/src/stacks/AppStack.ts
@@ -1,6 +1,6 @@
 import { Deployment } from 'kubernetes-models/apps/v1/Deployment';
 import { Service } from 'kubernetes-models/v1/Service';
-import { ResourceComposer, BaseStack, KubernetesSecretProvider } from '@kubricate/core';
+import { ResourceComposer, BaseStack } from '@kubricate/core';
 
 export interface IAppStack {
   namespace: string;

--- a/examples/with-secrets/tsconfig.json
+++ b/examples/with-secrets/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@kubricate/config-typescript/base.json",
+  "compilerOptions": {
+    "outDir": "dist/esm",
+    "declarationDir": "dist/dts",
+  },
+  "exclude": ["node_modules", "*.config.ts", "dist"]
+}

--- a/examples/with-stacks/eslint.config.mjs
+++ b/examples/with-stacks/eslint.config.mjs
@@ -1,0 +1,4 @@
+import { config } from "@kubricate/config-eslint/base";
+
+/** @type {import("eslint").Linter.Config} */
+export default config;

--- a/examples/with-stacks/package.json
+++ b/examples/with-stacks/package.json
@@ -13,7 +13,10 @@
     "README.md"
   ],
   "scripts": {
-    "kubricate": "kubricate"
+    "kubricate": "kubricate",
+    "lint:check": "mono lint:check",
+    "lint:fix": "mono lint:fix",
+    "check-types": "mono check-types"
   },
   "peerDependencies": {
     "@kubernetes-models/base": ">=5.0.1 <6.0.0"

--- a/examples/with-stacks/tsconfig.json
+++ b/examples/with-stacks/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@kubricate/config-typescript/base.json",
+  "compilerOptions": {
+    "outDir": "dist/esm",
+    "declarationDir": "dist/dts",
+  },
+  "exclude": ["node_modules", "*.config.ts", "dist"]
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "prepare": "husky && turbo run @kubricate/mono#build --output-logs=errors-only",
-    "build": "turbo run build --filter=!./examples/*",
+    "build": "turbo run build",
     "dev": "turbo run dev --filter=!./tools/template --filter=!./examples/*",
     "all": "run-s build lint:all",
     "lint:husky": "run-p lint:all format",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -29,8 +29,6 @@
 - 📦 Type-safe Kubernetes manifest generation with TypeScript
 - ♻️ Reusable, composable stack system
 - 🔐 Secrets injection via `SecretManager` and loaders (e.g., `.env`, process.env)
-- 📂 Structured output with Helm-compatible YAML
-- 🧪 Ready for testing and CI workflows
 
 ## Getting Started
 
@@ -118,8 +116,6 @@ Kubricate offers a type-safe developer experience for building Kubernetes manife
 - `@kubricate/stacks` – Official reusable stack definitions
 - `@kubricate/toolkit` – Utility functions for custom stack authors
 
----
-
 ## Version Compatibility
 
 Ensure the following packages are always on the same version when upgrading:
@@ -129,13 +125,9 @@ Ensure the following packages are always on the same version when upgrading:
 - `@kubricate/env`
 - `@kubricate/stacks`
 
----
-
 ## Documentation & Examples
 
 Explore the [`examples`](https://github.com/thaitype/kubricate/tree/main/examples) directory for real-world usage patterns and advanced features.
-
----
 
 ## Development
 
@@ -154,8 +146,6 @@ To run the examples run with
 ```sh
 pnpm --filter=@examples/with-custom-stack kubricate generate
 ```
-
----
 
 ## How to Publish
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,14 +1,168 @@
-# Kubricate
+<p align="center">
+  <a href="https://github.com/thaitype/kubricate">
+    <img src="https://i.ibb.co/hJTg9vhs/kubricate-logo.png" alt="kubricate-logo" width="120" />
+  </a>
+</p>
 
-A TypeScript framework for building, managing, and compiling Kubernetes resources with a structured, reusable, and Helm-compatible approach
+<h2 align="center">Kubricate</h2>
 
-## Example
+<p align="center">
+  A TypeScript framework for building, managing, and compiling Kubernetes resources with a structured, reusable, and Helm-compatible approach.
+</p>
 
-Run example
+<p align="center">
+  <a href="https://github.com/thaitype/kubricate/actions/workflows/test-and-build.yml">
+    <img src="https://github.com/thaitype/kubricate/actions/workflows/test-and-build.yml/badge.svg" alt="Build">
+  </a>
+  <a href="https://www.npmjs.com/package/kubricate">
+    <img alt="NPM Version" src="https://img.shields.io/npm/v/kubricate">
+  </a>
+  <a href="https://www.npmjs.com/package/kubricate">
+    <img src="https://img.shields.io/npm/dt/kubricate" alt="npm downloads">
+  </a>
+</p>
+
+> ⚠️ Experimental: This project is still in early development and not ready for production use.
+
+## Features
+
+- 📦 Type-safe Kubernetes manifest generation with TypeScript
+- ♻️ Reusable, composable stack system
+- 🔐 Secrets injection via `SecretManager` and loaders (e.g., `.env`, process.env)
+- 📂 Structured output with Helm-compatible YAML
+- 🧪 Ready for testing and CI workflows
+
+## Getting Started
+
+```bash
+npm install -D kubricate
+npm install @kubricate/core
+```
+
+If you want Kubernetes resource types in TypeScript, install `kubernetes-models`. It helps generate fully-typed resource objects.
+
+```bash
+npm install -D kubernetes-models
+```
+
+Then, create your first Kubricate Stack. Kubricate Stacks help you define, reuse, and manage Kubernetes resources in a clean, declarative way.
+
+### 🧱 Example: Creating a Namespace Stack
+
+```ts
+// File: src/my-stack.ts
+import { createStack, ResourceComposer } from '@kubricate/core';
+import { Namespace } from 'kubernetes-models/v1';
+
+// Step 1: declare data schema
+interface MyInput {
+  name: string;
+}
+
+// Step 2: define stack shape for reusable work
+const MyStack = createStack('MyStack', (data: MyInput) =>
+  new ResourceComposer().addClass({
+    id: 'namespace',
+    type: Namespace,
+    config: {
+      metadata: { name: data.name },
+    },
+  })
+);
+
+// Usage: configure the stack with your own input
+envexport const myStack = MyStack.from({
+  name: 'my-namespace',
+});
+```
+
+### ⚙️ Configure with `kubricate.config.ts`
+
+Create a `kubricate.config.ts` file at the root of your project:
+
+```ts
+import { defineConfig } from 'kubricate';
+import { myStack } from './src/MyStack';
+
+export default defineConfig({
+  stacks: {
+    myStack,
+  },
+});
+```
+
+### 🚀 Generate Kubernetes Resources
+
 ```bash
 npx kubricate generate
 ```
 
-## Usages
+This will generate Kubernetes YAML files in the `.kubricate` folder:
 
-See in the [examples](./examples) folder.
+```bash
+✔ YAML file successfully written to:
+  ~/with-custom-stack/.kubricate/stacks.yml
+```
+
+See the full working example: [`with-custom-stack`](https://github.com/thaitype/kubricate/tree/main/examples/with-custom-stack)
+
+Kubricate offers a type-safe developer experience for building Kubernetes manifests. It works with your existing resources, supports secret injection through loaders like `EnvLoader`, and prevents exposing secrets in YAML.
+
+---
+
+## Packages
+
+- `kubricate` – CLI for configuration and manifest generation
+- `@kubricate/core` – Core framework for creating and managing stacks
+- `@kubricate/env` – Secret loader for `.env` and environment variables
+- `@kubricate/stacks` – Official reusable stack definitions
+- `@kubricate/toolkit` – Utility functions for custom stack authors
+
+---
+
+## Version Compatibility
+
+Ensure the following packages are always on the same version when upgrading:
+
+- `kubricate`
+- `@kubricate/core`
+- `@kubricate/env`
+- `@kubricate/stacks`
+
+---
+
+## Documentation & Examples
+
+Explore the [`examples`](https://github.com/thaitype/kubricate/tree/main/examples) directory for real-world usage patterns and advanced features.
+
+---
+
+## Development
+
+To develop Kubricate:
+
+```bash
+pnpm install
+pnpm build
+pnpm dev
+```
+
+This installs dependencies and starts TypeScript in watch mode.
+
+To run the examples run with
+
+```sh
+pnpm --filter=@examples/with-custom-stack kubricate generate
+```
+
+---
+
+## How to Publish
+
+1. Run `pnpm changeset` and select the packages to version
+2. Commit and push the changes
+3. GitHub Actions will open a release PR
+4. Review and approve the PR
+5. The packages will be published to NPM automatically
+```
+

--- a/packages/core/src/BaseStack.ts
+++ b/packages/core/src/BaseStack.ts
@@ -24,10 +24,10 @@ export abstract class BaseStack<
   ConfigureComposerFunc extends FunctionLike<any[], ResourceComposer> = FunctionLike<any, ResourceComposer>,
   SecretManager extends AnySecretManager = AnySecretManager,
 > {
-  private _composer!: ReturnType<ConfigureComposerFunc>;
-  private _secretManagers: Record<string, SecretManager> = {};
-  private readonly _defaultSecretManagerId = 'default';
-  private _targetInjects: Record<string, ProviderInjection[]> = {};
+  public _composer!: ReturnType<ConfigureComposerFunc>;
+  public _secretManagers: Record<string, SecretManager> = {};
+  public readonly _defaultSecretManagerId = 'default';
+  public _targetInjects: Record<string, ProviderInjection[]> = {};
   public logger?: BaseLogger;
   /**
    * The name of the stack.
@@ -146,7 +146,7 @@ export abstract class BaseStack<
     return this._composer.build();
   }
 
-  protected setComposer(composer: ReturnType<ConfigureComposerFunc>) {
+  public setComposer(composer: ReturnType<ConfigureComposerFunc>) {
     this._composer = composer;
   }
 

--- a/packages/core/src/createStack.ts
+++ b/packages/core/src/createStack.ts
@@ -6,10 +6,10 @@ export type ConfigureComposerFunction<Data, Entries extends Record<string, unkno
 ) => ResourceComposer<Entries>;
 
 // Generic stack class that holds builder function internally
-class GenericStack<Data, Entries extends Record<string, unknown>> extends BaseStack<
+export class GenericStack<Data, Entries extends Record<string, unknown>> extends BaseStack<
   ConfigureComposerFunction<Data, Entries>
 > {
-  constructor(private builder: ConfigureComposerFunction<Data, Entries>) {
+  constructor(public builder: ConfigureComposerFunction<Data, Entries>) {
     super();
   }
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -29,8 +29,6 @@
 - 📦 Type-safe Kubernetes manifest generation with TypeScript
 - ♻️ Reusable, composable stack system
 - 🔐 Secrets injection via `SecretManager` and loaders (e.g., `.env`, process.env)
-- 📂 Structured output with Helm-compatible YAML
-- 🧪 Ready for testing and CI workflows
 
 ## Getting Started
 
@@ -118,8 +116,6 @@ Kubricate offers a type-safe developer experience for building Kubernetes manife
 - `@kubricate/stacks` – Official reusable stack definitions
 - `@kubricate/toolkit` – Utility functions for custom stack authors
 
----
-
 ## Version Compatibility
 
 Ensure the following packages are always on the same version when upgrading:
@@ -129,13 +125,9 @@ Ensure the following packages are always on the same version when upgrading:
 - `@kubricate/env`
 - `@kubricate/stacks`
 
----
-
 ## Documentation & Examples
 
 Explore the [`examples`](https://github.com/thaitype/kubricate/tree/main/examples) directory for real-world usage patterns and advanced features.
-
----
 
 ## Development
 
@@ -154,8 +146,6 @@ To run the examples run with
 ```sh
 pnpm --filter=@examples/with-custom-stack kubricate generate
 ```
-
----
 
 ## How to Publish
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -1,7 +1,168 @@
-# @kubricate/env
+<p align="center">
+  <a href="https://github.com/thaitype/kubricate">
+    <img src="https://i.ibb.co/hJTg9vhs/kubricate-logo.png" alt="kubricate-logo" width="120" />
+  </a>
+</p>
 
-Secret Loader for environment variables, designed to work with the secrets module in `@kubricate/core`.
+<h2 align="center">Kubricate</h2>
 
-This module provides support for loading secrets from `process.env` into the `SecretManager`.
+<p align="center">
+  A TypeScript framework for building, managing, and compiling Kubernetes resources with a structured, reusable, and Helm-compatible approach.
+</p>
 
-> Note: This module only supports **loading** secrets. Provider functionality is not available.
+<p align="center">
+  <a href="https://github.com/thaitype/kubricate/actions/workflows/test-and-build.yml">
+    <img src="https://github.com/thaitype/kubricate/actions/workflows/test-and-build.yml/badge.svg" alt="Build">
+  </a>
+  <a href="https://www.npmjs.com/package/kubricate">
+    <img alt="NPM Version" src="https://img.shields.io/npm/v/kubricate">
+  </a>
+  <a href="https://www.npmjs.com/package/kubricate">
+    <img src="https://img.shields.io/npm/dt/kubricate" alt="npm downloads">
+  </a>
+</p>
+
+> ⚠️ Experimental: This project is still in early development and not ready for production use.
+
+## Features
+
+- 📦 Type-safe Kubernetes manifest generation with TypeScript
+- ♻️ Reusable, composable stack system
+- 🔐 Secrets injection via `SecretManager` and loaders (e.g., `.env`, process.env)
+- 📂 Structured output with Helm-compatible YAML
+- 🧪 Ready for testing and CI workflows
+
+## Getting Started
+
+```bash
+npm install -D kubricate
+npm install @kubricate/core
+```
+
+If you want Kubernetes resource types in TypeScript, install `kubernetes-models`. It helps generate fully-typed resource objects.
+
+```bash
+npm install -D kubernetes-models
+```
+
+Then, create your first Kubricate Stack. Kubricate Stacks help you define, reuse, and manage Kubernetes resources in a clean, declarative way.
+
+### 🧱 Example: Creating a Namespace Stack
+
+```ts
+// File: src/my-stack.ts
+import { createStack, ResourceComposer } from '@kubricate/core';
+import { Namespace } from 'kubernetes-models/v1';
+
+// Step 1: declare data schema
+interface MyInput {
+  name: string;
+}
+
+// Step 2: define stack shape for reusable work
+const MyStack = createStack('MyStack', (data: MyInput) =>
+  new ResourceComposer().addClass({
+    id: 'namespace',
+    type: Namespace,
+    config: {
+      metadata: { name: data.name },
+    },
+  })
+);
+
+// Usage: configure the stack with your own input
+envexport const myStack = MyStack.from({
+  name: 'my-namespace',
+});
+```
+
+### ⚙️ Configure with `kubricate.config.ts`
+
+Create a `kubricate.config.ts` file at the root of your project:
+
+```ts
+import { defineConfig } from 'kubricate';
+import { myStack } from './src/MyStack';
+
+export default defineConfig({
+  stacks: {
+    myStack,
+  },
+});
+```
+
+### 🚀 Generate Kubernetes Resources
+
+```bash
+npx kubricate generate
+```
+
+This will generate Kubernetes YAML files in the `.kubricate` folder:
+
+```bash
+✔ YAML file successfully written to:
+  ~/with-custom-stack/.kubricate/stacks.yml
+```
+
+See the full working example: [`with-custom-stack`](https://github.com/thaitype/kubricate/tree/main/examples/with-custom-stack)
+
+Kubricate offers a type-safe developer experience for building Kubernetes manifests. It works with your existing resources, supports secret injection through loaders like `EnvLoader`, and prevents exposing secrets in YAML.
+
+---
+
+## Packages
+
+- `kubricate` – CLI for configuration and manifest generation
+- `@kubricate/core` – Core framework for creating and managing stacks
+- `@kubricate/env` – Secret loader for `.env` and environment variables
+- `@kubricate/stacks` – Official reusable stack definitions
+- `@kubricate/toolkit` – Utility functions for custom stack authors
+
+---
+
+## Version Compatibility
+
+Ensure the following packages are always on the same version when upgrading:
+
+- `kubricate`
+- `@kubricate/core`
+- `@kubricate/env`
+- `@kubricate/stacks`
+
+---
+
+## Documentation & Examples
+
+Explore the [`examples`](https://github.com/thaitype/kubricate/tree/main/examples) directory for real-world usage patterns and advanced features.
+
+---
+
+## Development
+
+To develop Kubricate:
+
+```bash
+pnpm install
+pnpm build
+pnpm dev
+```
+
+This installs dependencies and starts TypeScript in watch mode.
+
+To run the examples run with
+
+```sh
+pnpm --filter=@examples/with-custom-stack kubricate generate
+```
+
+---
+
+## How to Publish
+
+1. Run `pnpm changeset` and select the packages to version
+2. Commit and push the changes
+3. GitHub Actions will open a release PR
+4. Review and approve the PR
+5. The packages will be published to NPM automatically
+```
+

--- a/packages/kubricate/README.md
+++ b/packages/kubricate/README.md
@@ -1,12 +1,168 @@
-# Kubricate CLI
+<p align="center">
+  <a href="https://github.com/thaitype/kubricate">
+    <img src="https://i.ibb.co/hJTg9vhs/kubricate-logo.png" alt="kubricate-logo" width="120" />
+  </a>
+</p>
 
-Kubricate is a CLI tool that helps you manage Kubernetes configurations.
+<h2 align="center">Kubricate</h2>
 
-## Planned Features
-- command `generate` -- for generate into k8s yaml files, currenctly
-- command `apply` -- for apply into k8s cluster
-- command `delete` -- for delete from k8s cluster
-- command `diff` -- for diff between local and k8s cluster
-- command `init` -- for init kubricate project
-- command `plan` -- for plan kubricate project, like terraform plan
-- command `secrets` -- for manage secrets into k8s cluster
+<p align="center">
+  A TypeScript framework for building, managing, and compiling Kubernetes resources with a structured, reusable, and Helm-compatible approach.
+</p>
+
+<p align="center">
+  <a href="https://github.com/thaitype/kubricate/actions/workflows/test-and-build.yml">
+    <img src="https://github.com/thaitype/kubricate/actions/workflows/test-and-build.yml/badge.svg" alt="Build">
+  </a>
+  <a href="https://www.npmjs.com/package/kubricate">
+    <img alt="NPM Version" src="https://img.shields.io/npm/v/kubricate">
+  </a>
+  <a href="https://www.npmjs.com/package/kubricate">
+    <img src="https://img.shields.io/npm/dt/kubricate" alt="npm downloads">
+  </a>
+</p>
+
+> ⚠️ Experimental: This project is still in early development and not ready for production use.
+
+## Features
+
+- 📦 Type-safe Kubernetes manifest generation with TypeScript
+- ♻️ Reusable, composable stack system
+- 🔐 Secrets injection via `SecretManager` and loaders (e.g., `.env`, process.env)
+- 📂 Structured output with Helm-compatible YAML
+- 🧪 Ready for testing and CI workflows
+
+## Getting Started
+
+```bash
+npm install -D kubricate
+npm install @kubricate/core
+```
+
+If you want Kubernetes resource types in TypeScript, install `kubernetes-models`. It helps generate fully-typed resource objects.
+
+```bash
+npm install -D kubernetes-models
+```
+
+Then, create your first Kubricate Stack. Kubricate Stacks help you define, reuse, and manage Kubernetes resources in a clean, declarative way.
+
+### 🧱 Example: Creating a Namespace Stack
+
+```ts
+// File: src/my-stack.ts
+import { createStack, ResourceComposer } from '@kubricate/core';
+import { Namespace } from 'kubernetes-models/v1';
+
+// Step 1: declare data schema
+interface MyInput {
+  name: string;
+}
+
+// Step 2: define stack shape for reusable work
+const MyStack = createStack('MyStack', (data: MyInput) =>
+  new ResourceComposer().addClass({
+    id: 'namespace',
+    type: Namespace,
+    config: {
+      metadata: { name: data.name },
+    },
+  })
+);
+
+// Usage: configure the stack with your own input
+envexport const myStack = MyStack.from({
+  name: 'my-namespace',
+});
+```
+
+### ⚙️ Configure with `kubricate.config.ts`
+
+Create a `kubricate.config.ts` file at the root of your project:
+
+```ts
+import { defineConfig } from 'kubricate';
+import { myStack } from './src/MyStack';
+
+export default defineConfig({
+  stacks: {
+    myStack,
+  },
+});
+```
+
+### 🚀 Generate Kubernetes Resources
+
+```bash
+npx kubricate generate
+```
+
+This will generate Kubernetes YAML files in the `.kubricate` folder:
+
+```bash
+✔ YAML file successfully written to:
+  ~/with-custom-stack/.kubricate/stacks.yml
+```
+
+See the full working example: [`with-custom-stack`](https://github.com/thaitype/kubricate/tree/main/examples/with-custom-stack)
+
+Kubricate offers a type-safe developer experience for building Kubernetes manifests. It works with your existing resources, supports secret injection through loaders like `EnvLoader`, and prevents exposing secrets in YAML.
+
+---
+
+## Packages
+
+- `kubricate` – CLI for configuration and manifest generation
+- `@kubricate/core` – Core framework for creating and managing stacks
+- `@kubricate/env` – Secret loader for `.env` and environment variables
+- `@kubricate/stacks` – Official reusable stack definitions
+- `@kubricate/toolkit` – Utility functions for custom stack authors
+
+---
+
+## Version Compatibility
+
+Ensure the following packages are always on the same version when upgrading:
+
+- `kubricate`
+- `@kubricate/core`
+- `@kubricate/env`
+- `@kubricate/stacks`
+
+---
+
+## Documentation & Examples
+
+Explore the [`examples`](https://github.com/thaitype/kubricate/tree/main/examples) directory for real-world usage patterns and advanced features.
+
+---
+
+## Development
+
+To develop Kubricate:
+
+```bash
+pnpm install
+pnpm build
+pnpm dev
+```
+
+This installs dependencies and starts TypeScript in watch mode.
+
+To run the examples run with
+
+```sh
+pnpm --filter=@examples/with-custom-stack kubricate generate
+```
+
+---
+
+## How to Publish
+
+1. Run `pnpm changeset` and select the packages to version
+2. Commit and push the changes
+3. GitHub Actions will open a release PR
+4. Review and approve the PR
+5. The packages will be published to NPM automatically
+```
+

--- a/packages/kubricate/README.md
+++ b/packages/kubricate/README.md
@@ -29,8 +29,6 @@
 - 📦 Type-safe Kubernetes manifest generation with TypeScript
 - ♻️ Reusable, composable stack system
 - 🔐 Secrets injection via `SecretManager` and loaders (e.g., `.env`, process.env)
-- 📂 Structured output with Helm-compatible YAML
-- 🧪 Ready for testing and CI workflows
 
 ## Getting Started
 
@@ -118,8 +116,6 @@ Kubricate offers a type-safe developer experience for building Kubernetes manife
 - `@kubricate/stacks` – Official reusable stack definitions
 - `@kubricate/toolkit` – Utility functions for custom stack authors
 
----
-
 ## Version Compatibility
 
 Ensure the following packages are always on the same version when upgrading:
@@ -129,13 +125,9 @@ Ensure the following packages are always on the same version when upgrading:
 - `@kubricate/env`
 - `@kubricate/stacks`
 
----
-
 ## Documentation & Examples
 
 Explore the [`examples`](https://github.com/thaitype/kubricate/tree/main/examples) directory for real-world usage patterns and advanced features.
-
----
 
 ## Development
 
@@ -154,8 +146,6 @@ To run the examples run with
 ```sh
 pnpm --filter=@examples/with-custom-stack kubricate generate
 ```
-
----
 
 ## How to Publish
 

--- a/packages/stacks/README.md
+++ b/packages/stacks/README.md
@@ -29,8 +29,6 @@
 - 📦 Type-safe Kubernetes manifest generation with TypeScript
 - ♻️ Reusable, composable stack system
 - 🔐 Secrets injection via `SecretManager` and loaders (e.g., `.env`, process.env)
-- 📂 Structured output with Helm-compatible YAML
-- 🧪 Ready for testing and CI workflows
 
 ## Getting Started
 
@@ -118,8 +116,6 @@ Kubricate offers a type-safe developer experience for building Kubernetes manife
 - `@kubricate/stacks` – Official reusable stack definitions
 - `@kubricate/toolkit` – Utility functions for custom stack authors
 
----
-
 ## Version Compatibility
 
 Ensure the following packages are always on the same version when upgrading:
@@ -129,13 +125,9 @@ Ensure the following packages are always on the same version when upgrading:
 - `@kubricate/env`
 - `@kubricate/stacks`
 
----
-
 ## Documentation & Examples
 
 Explore the [`examples`](https://github.com/thaitype/kubricate/tree/main/examples) directory for real-world usage patterns and advanced features.
-
----
 
 ## Development
 
@@ -154,8 +146,6 @@ To run the examples run with
 ```sh
 pnpm --filter=@examples/with-custom-stack kubricate generate
 ```
-
----
 
 ## How to Publish
 

--- a/packages/stacks/README.md
+++ b/packages/stacks/README.md
@@ -1,53 +1,168 @@
-# @kubricate/stacks
+<p align="center">
+  <a href="https://github.com/thaitype/kubricate">
+    <img src="https://i.ibb.co/hJTg9vhs/kubricate-logo.png" alt="kubricate-logo" width="120" />
+  </a>
+</p>
 
-Official stack definitions for [kubricate](https://github.com/thaitype/kubricate), designed to simplify building Kubernetes resources in a structured and reusable way.
+<h2 align="center">Kubricate</h2>
 
-## Installation
+<p align="center">
+  A TypeScript framework for building, managing, and compiling Kubernetes resources with a structured, reusable, and Helm-compatible approach.
+</p>
+
+<p align="center">
+  <a href="https://github.com/thaitype/kubricate/actions/workflows/test-and-build.yml">
+    <img src="https://github.com/thaitype/kubricate/actions/workflows/test-and-build.yml/badge.svg" alt="Build">
+  </a>
+  <a href="https://www.npmjs.com/package/kubricate">
+    <img alt="NPM Version" src="https://img.shields.io/npm/v/kubricate">
+  </a>
+  <a href="https://www.npmjs.com/package/kubricate">
+    <img src="https://img.shields.io/npm/dt/kubricate" alt="npm downloads">
+  </a>
+</p>
+
+> ⚠️ Experimental: This project is still in early development and not ready for production use.
+
+## Features
+
+- 📦 Type-safe Kubernetes manifest generation with TypeScript
+- ♻️ Reusable, composable stack system
+- 🔐 Secrets injection via `SecretManager` and loaders (e.g., `.env`, process.env)
+- 📂 Structured output with Helm-compatible YAML
+- 🧪 Ready for testing and CI workflows
+
+## Getting Started
 
 ```bash
-pnpm install @kubricate/stacks 
-pnpm install -D @kubernetes-models/base@^5.0.1
+npm install -D kubricate
+npm install @kubricate/core
 ```
 
-`@kubernetes-models/base` is a required peer dependency.
-Please install it manually to ensure compatibility.
+If you want Kubernetes resource types in TypeScript, install `kubernetes-models`. It helps generate fully-typed resource objects.
 
-## Usage
-
-Currently, kubricate uses Kosko to compile stacks into Kubernetes resource YAML files.
-
-Create a component file at `components/MyApp.ts`:
-
-```typescript
-import { SimpleAppStack, NamespaceStack } from "@kubricate/stacks";
-
-const namespace = new NamespaceStack()
-  .configureStack({
-    name: "my-namespace"
-  })
-  .build();
-
-const myApp = new SimpleAppStack()
-  .configureStack({
-    imageName: "nginx",
-    name: "my-app"
-  })
-  .overrideStack({
-    service: {
-      spec: {
-        type: "LoadBalancer"
-      }
-    }
-  })
-  .build();
-
-export default [namespace, myApp];
+```bash
+npm install -D kubernetes-models
 ```
 
-### Generate Kubernetes Resources
+Then, create your first Kubricate Stack. Kubricate Stacks help you define, reuse, and manage Kubernetes resources in a clean, declarative way.
 
-Run the following command to generate resources from all components:
+### 🧱 Example: Creating a Namespace Stack
 
+```ts
+// File: src/my-stack.ts
+import { createStack, ResourceComposer } from '@kubricate/core';
+import { Namespace } from 'kubernetes-models/v1';
+
+// Step 1: declare data schema
+interface MyInput {
+  name: string;
+}
+
+// Step 2: define stack shape for reusable work
+const MyStack = createStack('MyStack', (data: MyInput) =>
+  new ResourceComposer().addClass({
+    id: 'namespace',
+    type: Namespace,
+    config: {
+      metadata: { name: data.name },
+    },
+  })
+);
+
+// Usage: configure the stack with your own input
+envexport const myStack = MyStack.from({
+  name: 'my-namespace',
+});
 ```
+
+### ⚙️ Configure with `kubricate.config.ts`
+
+Create a `kubricate.config.ts` file at the root of your project:
+
+```ts
+import { defineConfig } from 'kubricate';
+import { myStack } from './src/MyStack';
+
+export default defineConfig({
+  stacks: {
+    myStack,
+  },
+});
+```
+
+### 🚀 Generate Kubernetes Resources
+
+```bash
 npx kubricate generate
 ```
+
+This will generate Kubernetes YAML files in the `.kubricate` folder:
+
+```bash
+✔ YAML file successfully written to:
+  ~/with-custom-stack/.kubricate/stacks.yml
+```
+
+See the full working example: [`with-custom-stack`](https://github.com/thaitype/kubricate/tree/main/examples/with-custom-stack)
+
+Kubricate offers a type-safe developer experience for building Kubernetes manifests. It works with your existing resources, supports secret injection through loaders like `EnvLoader`, and prevents exposing secrets in YAML.
+
+---
+
+## Packages
+
+- `kubricate` – CLI for configuration and manifest generation
+- `@kubricate/core` – Core framework for creating and managing stacks
+- `@kubricate/env` – Secret loader for `.env` and environment variables
+- `@kubricate/stacks` – Official reusable stack definitions
+- `@kubricate/toolkit` – Utility functions for custom stack authors
+
+---
+
+## Version Compatibility
+
+Ensure the following packages are always on the same version when upgrading:
+
+- `kubricate`
+- `@kubricate/core`
+- `@kubricate/env`
+- `@kubricate/stacks`
+
+---
+
+## Documentation & Examples
+
+Explore the [`examples`](https://github.com/thaitype/kubricate/tree/main/examples) directory for real-world usage patterns and advanced features.
+
+---
+
+## Development
+
+To develop Kubricate:
+
+```bash
+pnpm install
+pnpm build
+pnpm dev
+```
+
+This installs dependencies and starts TypeScript in watch mode.
+
+To run the examples run with
+
+```sh
+pnpm --filter=@examples/with-custom-stack kubricate generate
+```
+
+---
+
+## How to Publish
+
+1. Run `pnpm changeset` and select the packages to version
+2. Commit and push the changes
+3. GitHub Actions will open a release PR
+4. Review and approve the PR
+5. The packages will be published to NPM automatically
+```
+

--- a/packages/toolkit/README.md
+++ b/packages/toolkit/README.md
@@ -29,8 +29,6 @@
 - 📦 Type-safe Kubernetes manifest generation with TypeScript
 - ♻️ Reusable, composable stack system
 - 🔐 Secrets injection via `SecretManager` and loaders (e.g., `.env`, process.env)
-- 📂 Structured output with Helm-compatible YAML
-- 🧪 Ready for testing and CI workflows
 
 ## Getting Started
 
@@ -118,8 +116,6 @@ Kubricate offers a type-safe developer experience for building Kubernetes manife
 - `@kubricate/stacks` – Official reusable stack definitions
 - `@kubricate/toolkit` – Utility functions for custom stack authors
 
----
-
 ## Version Compatibility
 
 Ensure the following packages are always on the same version when upgrading:
@@ -129,13 +125,9 @@ Ensure the following packages are always on the same version when upgrading:
 - `@kubricate/env`
 - `@kubricate/stacks`
 
----
-
 ## Documentation & Examples
 
 Explore the [`examples`](https://github.com/thaitype/kubricate/tree/main/examples) directory for real-world usage patterns and advanced features.
-
----
 
 ## Development
 
@@ -154,8 +146,6 @@ To run the examples run with
 ```sh
 pnpm --filter=@examples/with-custom-stack kubricate generate
 ```
-
----
 
 ## How to Publish
 

--- a/packages/toolkit/README.md
+++ b/packages/toolkit/README.md
@@ -1,3 +1,168 @@
-# @kubricate/toolkit
+<p align="center">
+  <a href="https://github.com/thaitype/kubricate">
+    <img src="https://i.ibb.co/hJTg9vhs/kubricate-logo.png" alt="kubricate-logo" width="120" />
+  </a>
+</p>
 
-Use for creating new projects.
+<h2 align="center">Kubricate</h2>
+
+<p align="center">
+  A TypeScript framework for building, managing, and compiling Kubernetes resources with a structured, reusable, and Helm-compatible approach.
+</p>
+
+<p align="center">
+  <a href="https://github.com/thaitype/kubricate/actions/workflows/test-and-build.yml">
+    <img src="https://github.com/thaitype/kubricate/actions/workflows/test-and-build.yml/badge.svg" alt="Build">
+  </a>
+  <a href="https://www.npmjs.com/package/kubricate">
+    <img alt="NPM Version" src="https://img.shields.io/npm/v/kubricate">
+  </a>
+  <a href="https://www.npmjs.com/package/kubricate">
+    <img src="https://img.shields.io/npm/dt/kubricate" alt="npm downloads">
+  </a>
+</p>
+
+> ⚠️ Experimental: This project is still in early development and not ready for production use.
+
+## Features
+
+- 📦 Type-safe Kubernetes manifest generation with TypeScript
+- ♻️ Reusable, composable stack system
+- 🔐 Secrets injection via `SecretManager` and loaders (e.g., `.env`, process.env)
+- 📂 Structured output with Helm-compatible YAML
+- 🧪 Ready for testing and CI workflows
+
+## Getting Started
+
+```bash
+npm install -D kubricate
+npm install @kubricate/core
+```
+
+If you want Kubernetes resource types in TypeScript, install `kubernetes-models`. It helps generate fully-typed resource objects.
+
+```bash
+npm install -D kubernetes-models
+```
+
+Then, create your first Kubricate Stack. Kubricate Stacks help you define, reuse, and manage Kubernetes resources in a clean, declarative way.
+
+### 🧱 Example: Creating a Namespace Stack
+
+```ts
+// File: src/my-stack.ts
+import { createStack, ResourceComposer } from '@kubricate/core';
+import { Namespace } from 'kubernetes-models/v1';
+
+// Step 1: declare data schema
+interface MyInput {
+  name: string;
+}
+
+// Step 2: define stack shape for reusable work
+const MyStack = createStack('MyStack', (data: MyInput) =>
+  new ResourceComposer().addClass({
+    id: 'namespace',
+    type: Namespace,
+    config: {
+      metadata: { name: data.name },
+    },
+  })
+);
+
+// Usage: configure the stack with your own input
+envexport const myStack = MyStack.from({
+  name: 'my-namespace',
+});
+```
+
+### ⚙️ Configure with `kubricate.config.ts`
+
+Create a `kubricate.config.ts` file at the root of your project:
+
+```ts
+import { defineConfig } from 'kubricate';
+import { myStack } from './src/MyStack';
+
+export default defineConfig({
+  stacks: {
+    myStack,
+  },
+});
+```
+
+### 🚀 Generate Kubernetes Resources
+
+```bash
+npx kubricate generate
+```
+
+This will generate Kubernetes YAML files in the `.kubricate` folder:
+
+```bash
+✔ YAML file successfully written to:
+  ~/with-custom-stack/.kubricate/stacks.yml
+```
+
+See the full working example: [`with-custom-stack`](https://github.com/thaitype/kubricate/tree/main/examples/with-custom-stack)
+
+Kubricate offers a type-safe developer experience for building Kubernetes manifests. It works with your existing resources, supports secret injection through loaders like `EnvLoader`, and prevents exposing secrets in YAML.
+
+---
+
+## Packages
+
+- `kubricate` – CLI for configuration and manifest generation
+- `@kubricate/core` – Core framework for creating and managing stacks
+- `@kubricate/env` – Secret loader for `.env` and environment variables
+- `@kubricate/stacks` – Official reusable stack definitions
+- `@kubricate/toolkit` – Utility functions for custom stack authors
+
+---
+
+## Version Compatibility
+
+Ensure the following packages are always on the same version when upgrading:
+
+- `kubricate`
+- `@kubricate/core`
+- `@kubricate/env`
+- `@kubricate/stacks`
+
+---
+
+## Documentation & Examples
+
+Explore the [`examples`](https://github.com/thaitype/kubricate/tree/main/examples) directory for real-world usage patterns and advanced features.
+
+---
+
+## Development
+
+To develop Kubricate:
+
+```bash
+pnpm install
+pnpm build
+pnpm dev
+```
+
+This installs dependencies and starts TypeScript in watch mode.
+
+To run the examples run with
+
+```sh
+pnpm --filter=@examples/with-custom-stack kubricate generate
+```
+
+---
+
+## How to Publish
+
+1. Run `pnpm changeset` and select the packages to version
+2. Commit and push the changes
+3. GitHub Actions will open a release PR
+4. Review and approve the PR
+5. The packages will be published to NPM automatically
+```
+


### PR DESCRIPTION
## 🧠 Fix Type Inference Issue with `createStack` Factory Function

This PR resolves a type inference issue when using the `createStack()` factory. It enhances the visibility and correctness of types inferred from `BaseStack` subclasses, improving DX for stack authors.

### ✅ What’s Fixed
- Improved the `createStack` implementation to preserve and infer types properly
- Ensures that methods like `.from()` on returned stacks are type-safe
- Avoids manual casting or loss of type information in downstream usage

### 🧩 Summary
This change improves developer experience by making custom stack definitions via `createStack()` properly typed, reducing the chance of runtime errors and improving IntelliSense support.