### PR TITLE
Refactor `inject()` API to Support 2-Argument Design and Rename `custom` Strategy to `plugin`

### DIFF
--- a/.changeset/great-pumas-tan.md
+++ b/.changeset/great-pumas-tan.md
@@ -1,0 +1,5 @@
+---
+'@kubricate/core': minor
+---
+
+Refactor inject() API to Support 2-Args Design for Secret Injection

--- a/packages/core/src/BaseStack.ts
+++ b/packages/core/src/BaseStack.ts
@@ -15,7 +15,7 @@ export type SecretInjectionStrategy =
   | { kind: 'annotation' }
   | { kind: 'imagePullSecret' }
   | { kind: 'envFrom'; containerIndex?: number }
-  | { kind: 'custom'; strategy: string; args: unknown[] };
+  | { kind: 'plugin'; action?: string; args?: unknown[]; [key: string]: unknown; };
 
 export interface UseSecretsOptions<Key extends AnyKey> {
   env?: EnvOptions<Key>[];

--- a/packages/core/src/secrets/SecretInjectionBuilder.ts
+++ b/packages/core/src/secrets/SecretInjectionBuilder.ts
@@ -72,27 +72,30 @@ export class SecretInjectionBuilder<Kinds extends SecretInjectionStrategy['kind'
    *
    * @example
    *   // Explicit strategy:
-   *   injector.secrets('APP_SECRET').inject({ kind: 'env', containerIndex: 0 });
+   *   injector.secrets('APP_SECRET').inject('env', { containerIndex: 0 });
    *
    *   // Implicit (default strategy):
    *   injector.secrets('APP_SECRET').inject(); // uses first provider-supported default
    */
   inject(): this;
-  inject(strategy: FallbackIfNever<ExtractAllowedKinds<Kinds>, SecretInjectionStrategy>): this;
+  inject(kind?: ExtractAllowedKinds<Kinds>['kind'], strategyOptions?: Omit<FallbackIfNever<ExtractAllowedKinds<Kinds>, SecretInjectionStrategy>, 'kind'>): this;
 
-  inject(strategy?: FallbackIfNever<ExtractAllowedKinds<Kinds>, SecretInjectionStrategy>): this {
-    if (!strategy) {
-      // If no strategy is provided, we can only default if exactly one is supported.
+  inject(kind?: ExtractAllowedKinds<Kinds>['kind'], strategyOptions?: Omit<FallbackIfNever<ExtractAllowedKinds<Kinds>, SecretInjectionStrategy>, 'kind'>): this {
+    if (kind === undefined) {
+      // no arguments provided
       if (this.provider.supportedStrategies.length !== 1) {
         throw new Error(
           `[SecretInjectionBuilder] inject() requires a strategy because provider supports multiple strategies: ${this.provider.supportedStrategies.join(', ')}`
         );
       }
 
-      const kind = this.provider.supportedStrategies[0];
-      this.strategy = this.resolveDefaultStrategy(kind)
+      const defaultKind = this.provider.supportedStrategies[0];
+      this.strategy = this.resolveDefaultStrategy(defaultKind);
     } else {
-      this.strategy = strategy;
+      this.strategy = {
+        kind,
+        ...strategyOptions,
+      } as SecretInjectionStrategy;
     }
 
     return this;


### PR DESCRIPTION
## **Refactor `inject()` API to Support 2-Argument Design and Rename `custom` Strategy to `plugin`**

This PR refactors the `inject()` method in `SecretInjectionBuilder` to support a new 2-argument signature as described in #56. The new API improves clarity, expressiveness, and flexibility for advanced secret injection scenarios.

---

### 🔁 Before (Deprecated Signature)

```tsx
inject({
  kind: 'env',
  containerIndex: 0,
});
```

### ✅ After (2-Argument API)

```tsx
inject('env', { containerIndex: 0 });
```

- The first argument is the `kind` of injection (`env`, `volume`, `annotation`, etc.)
- The second argument is an options object that varies by kind

### 🔹 `custom` → `plugin` Strategy Rename

**Old:**

```tsx
inject({
  kind: 'custom',
  strategy: 'vault-annotation',
  args: ['vault.hashicorp.com/secret', 'secret/data/myapp'],
});
```

**New:**

```tsx
inject('plugin', {
  action: 'vault-annotation',
  args: ['vault.hashicorp.com/secret', 'secret/data/myapp'],
});
```

- `kind: 'custom'` → `kind: 'plugin'`
- Renamed `strategy` to `action`
- `args` is now optional and more extensible (`[key: string]: unknown`)

### 🧩 Why This Matters

- Improves clarity of `inject()` API with consistent argument separation
- Supports plugin-based secret injection strategies cleanly
- Enables future extensions with optional `action`, `args`, and custom payloads
- Prepares the system for external/community plugin injection support
- Matches design direction proposed in [[#56](https://github.com/thaitype/kubricate/issues/56)](https://github.com/thaitype/kubricate/issues/56)

### 🧪 Example After Refactor

```tsx
injector.secrets('VAULT_TOKEN')
  .inject('plugin', {
    action: 'vault-annotation',
    args: ['vault.hashicorp.com/secret', 'secret/data/myapp'],
    annotationsOnly: true,
  });
```

This update is backward-incompatible for `custom` injectors and those who use the previous `inject()` shape. Custom strategy implementers should migrate to the new plugin-style injection with the 2-argument API.