### PR TITLE
Support Global CLI: `kbr` and `kubricate` Entry Points

### DIFF
--- a/examples/with-secrets/package.json
+++ b/examples/with-secrets/package.json
@@ -13,7 +13,7 @@
     "README.md"
   ],
   "scripts": {
-    "kubricate": "kubricate",
+    "kbr": "kbr",
     "lint:check": "mono lint:check",
     "lint:fix": "mono lint:fix",
     "check-types": "mono check-types"

--- a/packages/kubricate/package.json
+++ b/packages/kubricate/package.json
@@ -14,7 +14,8 @@
     }
   },
   "bin": {
-    "kubricate": "bin.mjs"
+    "kubricate": "bin.mjs",
+    "kbr": "bin.mjs"
   },
   "repository": {
     "type": "git",

--- a/packages/kubricate/src/cli-interfaces/entrypoint.ts
+++ b/packages/kubricate/src/cli-interfaces/entrypoint.ts
@@ -8,11 +8,12 @@ import type { LogLevel } from '@kubricate/core';
 
 export interface CliEntryPointOptions {
   version: string;
+  scriptName: string;
 }
 
 export function cliEntryPoint(argv: string[], options: CliEntryPointOptions) {
   yargs(hideBin(argv))
-    .scriptName('kubricate')
+    .scriptName(options.scriptName)
     .usage('$0 <command>')
     .version(options.version)
     // .epilog(c.red('Kubricate CLI - A CLI for managing Kubernetes stacks'))

--- a/packages/kubricate/src/cli.ts
+++ b/packages/kubricate/src/cli.ts
@@ -5,4 +5,5 @@ import { version } from './version.js';
 // This is the main entry point for the CLI application.
 cliEntryPoint(process.argv, {
   version,
+  scriptName: 'kbr',
 });


### PR DESCRIPTION
This PR adds support for using both `kbr` and `kubricate` as interchangeable CLI entry points, giving users flexibility in how they interact with the Kubricate framework. Whether you prefer full names or shorthand, the CLI now accommodates both styles seamlessly.

This enhancement improves developer experience across different environments and usage styles, supporting both local and global workflows.

---

### 🧪 Local Usage (via `npx`)

No installation required. You can use either command:

```bash
npx kubricate generate
npx kbr generate
npx kbr secret apply
```

> Note: The `kbr` package does not exist on npm. `npx kbr` only works after you've installed `kubricate` locally or the binary alias is available via project tooling.

---

### 🌐 Global Usage (via `npm install -g`)

After globally installing Kubricate, both commands are available system-wide:

```bash
npm install -g kubricate

kubricate generate
kubricate secret validate

kbr generate
kbr secret apply
```

---

This update makes Kubricate easier to adopt in diverse workflows, improves script ergonomics, and lays the foundation for future CLI enhancements including plugin support and extended tooling. The goal is to provide a flexible and consistent CLI experience regardless of your preferred command style.