### PR TITLE
🛠️ Fix: No such file or directory error when running kbr generate --root <root-kubricate-directory>

### DIFF
--- a/packages/kubricate/src/commands/generate.ts
+++ b/packages/kubricate/src/commands/generate.ts
@@ -80,8 +80,9 @@ export class GenerateCommand extends BaseCommand {
 
     logger.log(c.green`${MARK_CHECK} All stacks generated successfully`);
 
-    const outputPath = path.join(this.options.root ?? process.cwd(), this.options.outDir, 'stacks.yml');
-    await fs.mkdir(this.options.outDir, { recursive: true });
+    const outoutDir = path.join(this.options.root ?? process.cwd(), this.options.outDir);
+    const outputPath = path.join(outoutDir, 'stacks.yml');
+    await fs.mkdir(outoutDir, { recursive: true });
     await fs.writeFile(outputPath, output);
 
     logger.log('');


### PR DESCRIPTION
### 🛠️ Fix: No such file or directory error when running kbr generate --root <root-dir>
**🐞 Problem**
Running the kbr generate command with the --root option resulted in a no such file or directory error. This was due to the output directory not being created before attempting to write files to it.

**🔧 Solution**
✅ Fixed the variable reference to ensure the correct output directory is used.


**🚀 Impact**
Users can now successfully generate Kubernetes manifests with the --root flag without encountering directory errors.

🔗 Related Issue
Closes [#89](https://github.com/thaitype/kubricate/issues/89)