### PR TITLE
refactor: remove deprecated secrets config in defineConfig Options

### DIFF
--- a/packages/core/src/secret/orchestrator/SecretManagerEngine.test.ts
+++ b/packages/core/src/secret/orchestrator/SecretManagerEngine.test.ts
@@ -44,7 +44,7 @@ describe('SecretManagerEngine', () => {
           getSecretManagers: () => ({ main: mockSecretManager }),
         },
       },
-      secrets: {
+      secret: {
         manager: mockSecretManager
       }
     };
@@ -89,7 +89,7 @@ describe('SecretManagerEngine.collect()', () => {
       logger: mockLogger as any,
       effectOptions: {},
       config: {
-        secrets: { manager },
+        secret: { manager },
         stacks: {},
       },
     });
@@ -110,7 +110,7 @@ describe('SecretManagerEngine.collect()', () => {
       logger: mockLogger as any,
       effectOptions: {},
       config: {
-        secrets: { registry },
+        secret: { registry },
         stacks: {},
       },
     });
@@ -130,13 +130,13 @@ describe('SecretManagerEngine.collect()', () => {
       logger: mockLogger as any,
       effectOptions: {},
       config: {
-        secrets: { manager, registry },
+        secret: { manager, registry },
         stacks: {},
       },
     });
 
     expect(() => engine.collect()).toThrowError(
-      /Cannot define both "secrets\.manager" and "secrets\.registry"/
+      /Cannot define both "secret\.manager" and "secret\.registry"/
     );
   });
 
@@ -145,7 +145,7 @@ describe('SecretManagerEngine.collect()', () => {
       logger: mockLogger as any,
       effectOptions: {},
       config: {
-        secrets: {},
+        secret: {},
         stacks: {},
       },
     });

--- a/packages/core/src/secret/orchestrator/SecretManagerEngine.ts
+++ b/packages/core/src/secret/orchestrator/SecretManagerEngine.ts
@@ -50,25 +50,25 @@ export class SecretManagerEngine {
     logger.info('Collecting secret managers...');
 
     // 🚨 Enforce mutual exclusivity
-    if (config.secrets?.manager && config.secrets?.registry) {
-      throw new Error('[config] Cannot define both "secrets.manager" and "secrets.registry" — please choose one.');
+    if (config.secret?.manager && config.secret?.registry) {
+      throw new Error('[config] Cannot define both "secret.manager" and "secret.registry" — please choose one.');
     }
 
     const result: MergedSecretManager = {};
 
-    if (config.secrets?.registry) {
+    if (config.secret?.registry) {
       // 📦 Use SecretRegistry
-      for (const [name, manager] of Object.entries(config.secrets.registry.list())) {
+      for (const [name, manager] of Object.entries(config.secret.registry.list())) {
         result[name] = {
           name,
           secretManager: manager,
         };
       }
-    } else if (config.secrets?.manager) {
+    } else if (config.secret?.manager) {
       // 📦 Use Single Manager
       result.default = {
         name: 'default',
-        secretManager: config.secrets.manager,
+        secretManager: config.secret.manager,
       };
     } else {
       throw new Error('[config] No secret manager found. Please define either "secrets.manager" or "secrets.registry" in kubricate.config.ts.');

--- a/packages/core/src/secret/orchestrator/SecretsOrchestrator.test.ts
+++ b/packages/core/src/secret/orchestrator/SecretsOrchestrator.test.ts
@@ -61,7 +61,7 @@ describe('SecretsOrchestrator', () => {
             })
           } as any
         },
-        secrets: {
+        secret: {
           conflict: {
             strategies: {
               intraProvider: 'autoMerge',
@@ -167,7 +167,7 @@ describe('SecretsOrchestrator Multi-Level Merge Strategy', () => {
       effectOptions: {},
       config: {
         stacks: stacks as any,
-        secrets: {
+        secret: {
           conflict: {
             strategies: {
               intraProvider: 'autoMerge',
@@ -248,7 +248,7 @@ describe('SecretsOrchestrator Advanced Merge Tests', () => {
       effectOptions: {},
       config: {
         stacks: stacks as any,
-        secrets: {
+        secret: {
           conflict: {
             strategies: {
               intraProvider: 'autoMerge',
@@ -309,7 +309,7 @@ describe('SecretsOrchestrator intraProvider  (Integration Tests)', () => {
       effectOptions: {},
       config: {
         stacks: stacks as any,
-        secrets: {
+        secret: {
           manager: secretManager,
           conflict: {
             strategies: {
@@ -354,7 +354,7 @@ describe('SecretsOrchestrator intraProvider  (Integration Tests)', () => {
       effectOptions: {},
       config: {
         stacks: stacks as any,
-        secrets: {
+        secret: {
           manager: secretManager,
           conflict: {
             strategies: {
@@ -403,7 +403,7 @@ describe('SecretsOrchestrator intraProvider  (Integration Tests)', () => {
       effectOptions: {},
       config: {
         stacks: stacks as any,
-        secrets: {
+        secret: {
           manager: secretManager,
           conflict: {
             strategies: {
@@ -452,7 +452,7 @@ describe('SecretsOrchestrator intraProvider  (Integration Tests)', () => {
       effectOptions: {},
       config: {
         stacks: stacks as any,
-        secrets: {
+        secret: {
           manager: secretManager,
           conflict: { strategies: { intraProvider: 'overwrite' } }
         }
@@ -518,7 +518,7 @@ describe('SecretsOrchestrator crossProvider (Integration Tests)', () => {
       effectOptions: {},
       config: {
         stacks: stacks as any,
-        secrets: {
+        secret: {
           manager: secretManager,
           conflict: {
             strategies: {
@@ -572,7 +572,7 @@ describe('SecretsOrchestrator crossProvider (Integration Tests)', () => {
       effectOptions: {},
       config: {
         stacks: stacks as any,
-        secrets: {
+        secret: {
           manager: secretManager,
           conflict: {
             strategies: {
@@ -621,7 +621,7 @@ describe('SecretsOrchestrator crossProvider (Integration Tests)', () => {
       effectOptions: {},
       config: {
         stacks: stacks as any,
-        secrets: {
+        secret: {
           manager: secretManager,
           conflict: {
             strategies: { crossProvider: 'overwrite' },
@@ -668,7 +668,7 @@ describe('SecretsOrchestrator crossProvider (Integration Tests)', () => {
       effectOptions: {},
       config: {
         stacks: stacks as any,
-        secrets: {
+        secret: {
           manager: secretManager,
           conflict: { strategies: { crossProvider: 'overwrite' } }
         }
@@ -725,7 +725,7 @@ describe('SecretsOrchestrator crossManager (Integration Tests)', () => {
       effectOptions: {},
       config: {
         stacks: { app: stack as any },
-        secrets: {
+        secret: {
           registry: secretRegistry,
           conflict: {
             strategies: { crossManager: 'error' as const },
@@ -765,7 +765,7 @@ describe('SecretsOrchestrator crossManager (Integration Tests)', () => {
       effectOptions: {},
       config: {
         stacks: { app: stack as any },
-        secrets: {
+        secret: {
           registry: secretRegistry,
           conflict: {
             strategies: { crossManager: 'autoMerge' as const },
@@ -813,7 +813,7 @@ describe('SecretsOrchestrator crossManager (Integration Tests)', () => {
       effectOptions: {},
       config: {
         stacks: stacks as any,
-        secrets: {
+        secret: {
           registry: secretRegistry,
           conflict: {
             strategies: { crossManager: 'overwrite' },
@@ -858,7 +858,7 @@ describe('SecretsOrchestrator crossManager (Integration Tests)', () => {
       effectOptions: {},
       config: {
         stacks: stacks as any,
-        secrets: {
+        secret: {
           registry: secretRegistry,
           conflict: { strategies: { crossManager: 'overwrite' } }
         }
@@ -906,7 +906,7 @@ describe('SecretsOrchestrator crossManager (Integration Tests)', () => {
       effectOptions: {},
       config: {
         stacks: { app: { getSecretManagers: () => ({ svc1, svc2 }) } as any },
-        secrets: {
+        secret: {
           registry: secretRegistry,
           conflict: { strategies: { crossManager: 'error' } },
         },
@@ -937,7 +937,7 @@ describe('SecretsOrchestrator crossManager (Integration Tests)', () => {
       effectOptions: {},
       config: {
         stacks: { app: { getSecretManagers: () => ({ svc1, svc2 }) } as any },
-        secrets: {
+        secret: {
           registry: secretRegistry,
           conflict: { strategies: { crossManager: 'overwrite' } },
         },
@@ -971,7 +971,7 @@ describe('SecretsOrchestrator crossManager (Integration Tests)', () => {
       effectOptions: {},
       config: {
         stacks: { app: { getSecretManagers: () => ({ svc1, svc2 }) } as any },
-        secrets: {
+        secret: {
           registry: secretRegistry,
           conflict: { strategies: { crossManager: 'autoMerge' } },
         },
@@ -1028,7 +1028,7 @@ describe('SecretsOrchestrator cross-stack using single SecretManager (Integratio
       effectOptions: {},
       config: {
         stacks: stacks as any,
-        secrets: {
+        secret: {
           manager: sharedManager,
         },
       },
@@ -1091,7 +1091,7 @@ describe('SecretsOrchestrator strictConflictMode (Negative Test)', () => {
       effectOptions: {},
       config: {
         stacks: stacks as any,
-        secrets: {
+        secret: {
           manager: sharedManager,
           conflict: {
             strict: true,
@@ -1156,7 +1156,7 @@ describe('SecretsOrchestrator Cross-Manager Conflict Detection', () => {
       effectOptions: {},
       config: {
         stacks: stacks as any,
-        secrets: {
+        secret: {
           registry: secretRegistry,
           conflict: {
             strategies: {
@@ -1217,7 +1217,7 @@ describe('SecretsOrchestrator - Multiple SecretManagers with Same Provider Name'
     const orchestrator = SecretsOrchestrator.create({
       effectOptions: {},
       config: {
-        secrets: {
+        secret: {
           registry: secretRegistry,
         },
         stacks: {},

--- a/packages/core/src/secret/orchestrator/SecretsOrchestrator.ts
+++ b/packages/core/src/secret/orchestrator/SecretsOrchestrator.ts
@@ -114,7 +114,7 @@ export class SecretsOrchestrator {
   async apply(): Promise<PreparedEffect[]> {
     const managers = await this.validate();
 
-    this.logOrchestratorContext(this.engine.options.config.secrets);
+    this.logOrchestratorContext(this.engine.options.config.secret);
 
     // 1. Load and resolve all secrets
     const resolvedSecrets = await this.loadSecretsFromManagers(managers);
@@ -233,7 +233,7 @@ export class SecretsOrchestrator {
           providerNames.size > 1 ? 'crossProvider' :
             'intraProvider';
 
-      const strategy = this.resolveStrategyForLevel(level, this.engine.options.config.secrets);
+      const strategy = this.resolveStrategyForLevel(level, this.engine.options.config.secret);
       const providerName = group[0].providerName;
       const provider = this.resolveProviderByName(providerName, group[0].managerName);
 
@@ -352,7 +352,7 @@ export class SecretsOrchestrator {
    */
   private validateConfig(config: KubricateConfig): void {
     // Validate conflict options
-    this.validateConflictOptions(config.secrets);
+    this.validateConflictOptions(config.secret);
   }
 
   /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -90,12 +90,6 @@ export interface KubricateConfig {
   metadata?: ProjectMetadataOptions;
   /**
    * Secrets configuration
-   * 
-   * @deprecated Use `secret` instead
-   */
-  secrets?: ProjectSecretOptions;
-  /**
-   * Secret configuration
    */
   secret?: ProjectSecretOptions;
   generate?: ProjectGenerateOptions;

--- a/packages/kubricate/src/commands/ConfigLoader.ts
+++ b/packages/kubricate/src/commands/ConfigLoader.ts
@@ -75,27 +75,11 @@ export class ConfigLoader {
     }
   }
 
-  protected handleDeprecatedSecretOptions(config: KubricateConfig | undefined): KubricateConfig | undefined {
-    if (!config) return config;
-    if (config.secrets && config.secret) {
-      throw new Error(`Conflict between 'secret' and 'secrets' options. Please use 'secret' instead`);
-    }
-    if (config.secrets) {
-      this.logger.warn(`The 'secrets' option is deprecated. Please use 'secret' instead.`);
-    }
-    if (config.secret) {
-      config.secrets = config.secret;
-    }
-    return config;
-  }
-
   public async load(): Promise<KubricateConfig> {
     const logger = this.logger;
     logger.debug('Initializing secrets orchestrator...');
-    let config: KubricateConfig | undefined;
     logger.debug('Loading configuration...');
-    config = await getConfig(this.options);
-    config = this.handleDeprecatedSecretOptions(config);
+    const config = await getConfig(this.options);
     if (!config) {
       logger.error(`No config file found matching '${getMatchConfigFile()}'`);
       logger.error(`Please ensure a config file exists in the root directory:\n   ${this.options.root}`);


### PR DESCRIPTION
This PR removes the deprecated `secrets` field from the `defineConfig` options to simplify and clean up the configuration interface.

#### 🔧 Changes

- Removed the `secrets` property from `defineConfig`.
- Cleaned up related tests and internal logic.
- Removed unused secret-related utilities tied to the old config.

#### 🧪 Testing

- All affected tests were updated or removed.
- Verified no regressions in config parsing or secret loading.

#### 📌 Notes

This aligns with the deprecation plan and prepares for a cleaner configuration model. Users should no longer use `secrets` directly in `defineConfig`.