### PR TITLE
Deprecate `secret.manager` and `secret.registry` in favor of `secretSpec`

### DIFF
--- a/examples/with-secret-registry/kubricate.config.ts
+++ b/examples/with-secret-registry/kubricate.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     ...simpleAppStack,
   },
   secret: {
-    registry: secretRegistry,
+    secretSpec: secretRegistry,
     conflict: {
       strategies: {
         // Default conflict handling strategies

--- a/examples/with-secret/kubricate.config.ts
+++ b/examples/with-secret/kubricate.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     ...simpleAppStack,
   },
   secret: {
-    manager: secretManager,
+    secretSpec: secretManager,
     conflict: {
       strategies: {
         // Default conflict handling strategies

--- a/packages/core/src/secret/orchestrator/SecretManagerEngine.test.ts
+++ b/packages/core/src/secret/orchestrator/SecretManagerEngine.test.ts
@@ -45,7 +45,7 @@ describe('SecretManagerEngine', () => {
         },
       },
       secret: {
-        manager: mockSecretManager
+        secretSpec: mockSecretManager
       }
     };
   });
@@ -89,7 +89,7 @@ describe('SecretManagerEngine.collect()', () => {
       logger: mockLogger as any,
       effectOptions: {},
       config: {
-        secret: { manager },
+        secret: { secretSpec: manager },
         stacks: {},
       },
     });
@@ -110,7 +110,7 @@ describe('SecretManagerEngine.collect()', () => {
       logger: mockLogger as any,
       effectOptions: {},
       config: {
-        secret: { registry },
+        secret: { secretSpec: registry },
         stacks: {},
       },
     });
@@ -120,24 +120,6 @@ describe('SecretManagerEngine.collect()', () => {
     expect(Object.keys(result)).toEqual(['svc1', 'svc2']);
     expect(result.svc1.secretManager).toBeInstanceOf(SecretManager);
     expect(result.svc2.secretManager).toBeInstanceOf(SecretManager);
-  });
-
-  it('throws if both manager and registry are defined', () => {
-    const manager = new SecretManager();
-    const registry = new SecretRegistry().add('svc1', new SecretManager());
-
-    const engine = new SecretManagerEngine({
-      logger: mockLogger as any,
-      effectOptions: {},
-      config: {
-        secret: { manager, registry },
-        stacks: {},
-      },
-    });
-
-    expect(() => engine.collect()).toThrowError(
-      /Cannot define both "secret\.manager" and "secret\.registry"/
-    );
   });
 
   it('throws if neither manager nor registry are defined', () => {
@@ -151,7 +133,7 @@ describe('SecretManagerEngine.collect()', () => {
     });
 
     expect(() => engine.collect()).toThrowError(
-      /No secret manager found/
+      /No secret manager or secret registry/
     );
   });
 });

--- a/packages/core/src/secret/orchestrator/SecretsOrchestrator.test.ts
+++ b/packages/core/src/secret/orchestrator/SecretsOrchestrator.test.ts
@@ -69,7 +69,7 @@ describe('SecretsOrchestrator', () => {
               crossManager: 'error',
             }
           },
-          manager: mockSecretManager,
+          secretSpec: mockSecretManager,
         }
       },
       logger: mockLogger,
@@ -175,7 +175,7 @@ describe('SecretsOrchestrator Multi-Level Merge Strategy', () => {
               crossManager: 'autoMerge',
             }
           },
-          manager: _mockSecretManager,
+          secretSpec: _mockSecretManager,
         }
       }
     };
@@ -254,7 +254,7 @@ describe('SecretsOrchestrator Advanced Merge Tests', () => {
               intraProvider: 'autoMerge',
             }
           },
-          manager: _mockSecretManager,
+          secretSpec: _mockSecretManager,
         }
       }
     };
@@ -310,7 +310,7 @@ describe('SecretsOrchestrator intraProvider  (Integration Tests)', () => {
       config: {
         stacks: stacks as any,
         secret: {
-          manager: secretManager,
+          secretSpec: secretManager,
           conflict: {
             strategies: {
               intraProvider: 'error', // This will trigger the error
@@ -355,7 +355,7 @@ describe('SecretsOrchestrator intraProvider  (Integration Tests)', () => {
       config: {
         stacks: stacks as any,
         secret: {
-          manager: secretManager,
+          secretSpec: secretManager,
           conflict: {
             strategies: {
               intraProvider: 'autoMerge',
@@ -404,7 +404,7 @@ describe('SecretsOrchestrator intraProvider  (Integration Tests)', () => {
       config: {
         stacks: stacks as any,
         secret: {
-          manager: secretManager,
+          secretSpec: secretManager,
           conflict: {
             strategies: {
               intraProvider: 'overwrite',
@@ -453,7 +453,7 @@ describe('SecretsOrchestrator intraProvider  (Integration Tests)', () => {
       config: {
         stacks: stacks as any,
         secret: {
-          manager: secretManager,
+          secretSpec: secretManager,
           conflict: { strategies: { intraProvider: 'overwrite' } }
         }
       }
@@ -519,7 +519,7 @@ describe('SecretsOrchestrator crossProvider (Integration Tests)', () => {
       config: {
         stacks: stacks as any,
         secret: {
-          manager: secretManager,
+          secretSpec: secretManager,
           conflict: {
             strategies: {
               crossProvider: 'error',
@@ -573,7 +573,7 @@ describe('SecretsOrchestrator crossProvider (Integration Tests)', () => {
       config: {
         stacks: stacks as any,
         secret: {
-          manager: secretManager,
+          secretSpec: secretManager,
           conflict: {
             strategies: {
               crossProvider: 'autoMerge',
@@ -622,7 +622,7 @@ describe('SecretsOrchestrator crossProvider (Integration Tests)', () => {
       config: {
         stacks: stacks as any,
         secret: {
-          manager: secretManager,
+          secretSpec: secretManager,
           conflict: {
             strategies: { crossProvider: 'overwrite' },
           }
@@ -669,7 +669,7 @@ describe('SecretsOrchestrator crossProvider (Integration Tests)', () => {
       config: {
         stacks: stacks as any,
         secret: {
-          manager: secretManager,
+          secretSpec: secretManager,
           conflict: { strategies: { crossProvider: 'overwrite' } }
         }
       }
@@ -726,7 +726,7 @@ describe('SecretsOrchestrator crossManager (Integration Tests)', () => {
       config: {
         stacks: { app: stack as any },
         secret: {
-          registry: secretRegistry,
+          secretSpec: secretRegistry,
           conflict: {
             strategies: { crossManager: 'error' as const },
           }
@@ -766,7 +766,7 @@ describe('SecretsOrchestrator crossManager (Integration Tests)', () => {
       config: {
         stacks: { app: stack as any },
         secret: {
-          registry: secretRegistry,
+          secretSpec: secretRegistry,
           conflict: {
             strategies: { crossManager: 'autoMerge' as const },
           }
@@ -814,7 +814,7 @@ describe('SecretsOrchestrator crossManager (Integration Tests)', () => {
       config: {
         stacks: stacks as any,
         secret: {
-          registry: secretRegistry,
+          secretSpec: secretRegistry,
           conflict: {
             strategies: { crossManager: 'overwrite' },
           }
@@ -859,7 +859,7 @@ describe('SecretsOrchestrator crossManager (Integration Tests)', () => {
       config: {
         stacks: stacks as any,
         secret: {
-          registry: secretRegistry,
+          secretSpec: secretRegistry,
           conflict: { strategies: { crossManager: 'overwrite' } }
         }
       }
@@ -907,7 +907,7 @@ describe('SecretsOrchestrator crossManager (Integration Tests)', () => {
       config: {
         stacks: { app: { getSecretManagers: () => ({ svc1, svc2 }) } as any },
         secret: {
-          registry: secretRegistry,
+          secretSpec: secretRegistry,
           conflict: { strategies: { crossManager: 'error' } },
         },
       },
@@ -938,7 +938,7 @@ describe('SecretsOrchestrator crossManager (Integration Tests)', () => {
       config: {
         stacks: { app: { getSecretManagers: () => ({ svc1, svc2 }) } as any },
         secret: {
-          registry: secretRegistry,
+          secretSpec: secretRegistry,
           conflict: { strategies: { crossManager: 'overwrite' } },
         },
       },
@@ -972,7 +972,7 @@ describe('SecretsOrchestrator crossManager (Integration Tests)', () => {
       config: {
         stacks: { app: { getSecretManagers: () => ({ svc1, svc2 }) } as any },
         secret: {
-          registry: secretRegistry,
+          secretSpec: secretRegistry,
           conflict: { strategies: { crossManager: 'autoMerge' } },
         },
       },
@@ -1029,7 +1029,7 @@ describe('SecretsOrchestrator cross-stack using single SecretManager (Integratio
       config: {
         stacks: stacks as any,
         secret: {
-          manager: sharedManager,
+          secretSpec: sharedManager,
         },
       },
     };
@@ -1157,7 +1157,7 @@ describe('SecretsOrchestrator Cross-Manager Conflict Detection', () => {
       config: {
         stacks: stacks as any,
         secret: {
-          registry: secretRegistry,
+          secretSpec: secretRegistry,
           conflict: {
             strategies: {
               crossManager: 'error', // ❗ สำคัญ
@@ -1218,7 +1218,7 @@ describe('SecretsOrchestrator - Multiple SecretManagers with Same Provider Name'
       effectOptions: {},
       config: {
         secret: {
-          registry: secretRegistry,
+          secretSpec: secretRegistry,
         },
         stacks: {},
       },

--- a/packages/core/src/secret/types.ts
+++ b/packages/core/src/secret/types.ts
@@ -19,7 +19,7 @@ export type ExtractSecretManager<Registry extends AnySecretManager> = {
  * Represents any type of SecretManager for type extraction purposes.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type AnySecretManager = SecretManager<any, any>;
+export type AnySecretManager = SecretManager<any, any, any, any>;
 
 /**
  * Represents the options for environment variables in a Kubernetes deployment.
@@ -69,6 +69,11 @@ export interface SecretManagerRegistrationOptions {
    * @deprecated Use `secretSpec` instead, which most support both SecretManager and SecretRegistry
    */
   registry?: SecretRegistry;
+
+  /**
+   * Register a secret manager or secret registry.
+   */
+  secretSpec?: AnySecretManager | SecretRegistry;
 }
 
 export type ProjectSecretOptions = SecretManagerRegistrationOptions & ConfigConflictOptions;

--- a/tests/fixtures/generate-with-secret-manager/kubricate.config.ts
+++ b/tests/fixtures/generate-with-secret-manager/kubricate.config.ts
@@ -3,7 +3,7 @@ import { frontendSecretManager, metadata, sharedStacks } from '../shared-configs
 
 export default defineConfig({
   secret: {
-    manager: frontendSecretManager,
+    secretSpec: frontendSecretManager,
   },
   stacks: {
     namespace: sharedStacks.namespace,

--- a/tests/fixtures/generate-with-secret-registry/kubricate.config.ts
+++ b/tests/fixtures/generate-with-secret-registry/kubricate.config.ts
@@ -3,7 +3,7 @@ import { metadata, secretRegistry, sharedStacks } from '../shared-configs';
 
 export default defineConfig({
   secret: {
-    registry: secretRegistry
+    secretSpec: secretRegistry
   },
   stacks: {
     namespace: sharedStacks.namespace,


### PR DESCRIPTION
This PR introduces a transitional update to Kubricate's config system by **marking `secret.manager` and `secret.registry` as deprecated**, and internally migrating them to the new unified field: `secret.secretSpec`.

### ✅ Summary

- Adds support for `secret.secretSpec`, which accepts either a `SecretManager` or a `SecretRegistry`
- If legacy fields `manager` or `registry` are provided, a deprecation warning is shown and the config is normalized to use `secretSpec`
- Throws an error if both `manager` and `registry` are defined together
- No CLI or runtime behavior changes — purely config normalization

### 🧱 Before (legacy)

```ts
defineConfig({
  secret: {
    manager: mySecretManager
  }
});
```

or

```ts
defineConfig({
  secret: {
    registry: myRegistry
  }
});
```

### ✅ After (preferred)

```ts
defineConfig({
  secret: {
    secretSpec: mySecretManagerOrRegistry
  }
});
```

### 🔁 Runtime Behavior

- If `secretSpec` is defined → used directly
- If `manager` or `registry` is defined → logs a warning and internally maps to `secretSpec`
- If both `manager` and `registry` → ❌ throws error

### 🧠 Why this matters

| Goal                       | Outcome |
|---------------------------|---------|
| ✅ Unifies config entrypoint | Sets foundation for `env.dev.secretSpec` in the future |
| ⚠️ Warns early               | Makes migration path visible but non-breaking |
| 🧼 Prevents ambiguity        | Mutual exclusivity check for old fields |

### 🚫 Out of Scope

- No CLI changes
- No support for per-environment secrets yet
- No removal of `manager`/`registry` — just soft-deprecation

This is a **non-breaking step** toward the future config format. A follow-up PR can handle full migration and support for environment-specific `secretSpec`.