### PR TITLE
Refactor: Rename Plugin Packages to Use `@kubricate/plugin-*` Convention

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": true,
-  "fixed": [["kubricate", "@kubricate/core", "@kubricate/env", "@kubricate/stacks", "@kubricate/kubernetes"]],
+  "fixed": [["kubricate", "@kubricate/core", "@kubricate/plugin-env", "@kubricate/stacks", "@kubricate/kubernetes"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": true,
-  "fixed": [["kubricate", "@kubricate/core", "@kubricate/plugin-env", "@kubricate/stacks", "@kubricate/kubernetes"]],
+  "fixed": [["kubricate", "@kubricate/core", "@kubricate/plugin-env", "@kubricate/stacks", "@kubricate/plugin-kubernetes"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",

--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ Documentation is in progress, please explore the [`examples`](https://github.com
 
 - `kubricate` – CLI for configuration and manifest generation
 - `@kubricate/core` – Core framework for creating and managing stacks
-- `@kubricate/env` – Secret connector for `.env` and environment variables
+- `@kubricate/plugin-env` – Secret connector for `.env` and environment variables
 - `@kubricate/kubernetes` – Kubernetes connectors
 - `@kubricate/stacks` – Official reusable stack definitions
 - `@kubricate/toolkit` – Utility functions for custom stack authors
@@ -392,7 +392,7 @@ Ensure the following packages are always on the same version when upgrading:
 
 - `kubricate`
 - `@kubricate/core`
-- `@kubricate/env`
+- `@kubricate/plugin-env`
 - `@kubricate/kubernetes`
 - `@kubricate/stacks`
 

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ Documentation is in progress, please explore the [`examples`](https://github.com
 - `kubricate` – CLI for configuration and manifest generation
 - `@kubricate/core` – Core framework for creating and managing stacks
 - `@kubricate/plugin-env` – Secret connector for `.env` and environment variables
-- `@kubricate/kubernetes` – Kubernetes connectors
+- `@kubricate/plugin-kubernetes` – Kubernetes connectors
 - `@kubricate/stacks` – Official reusable stack definitions
 - `@kubricate/toolkit` – Utility functions for custom stack authors
 
@@ -393,7 +393,7 @@ Ensure the following packages are always on the same version when upgrading:
 - `kubricate`
 - `@kubricate/core`
 - `@kubricate/plugin-env`
-- `@kubricate/kubernetes`
+- `@kubricate/plugin-kubernetes`
 - `@kubricate/stacks`
 
 ## Development

--- a/docs/monorepo-maintenance-guide.md
+++ b/docs/monorepo-maintenance-guide.md
@@ -11,7 +11,7 @@ This monorepo uses [Changesets](https://github.com/changesets/changesets) for **
 - `@kubricate/toolkit` — independent tools
 - `kubricate` — CLI tool (uses `core` only for setup config types)
 - Future packages:
-  - `@kubricate/env`, `@kubricate/secrets`, `@kubricate/azure-keyvault` → depend on `core`
+  - `@kubricate/plugin-env`, `@kubricate/plugin-secrets`, `@kubricate/plugin-azure-keyvault` → depend on `core`
 
 ---
 
@@ -21,7 +21,7 @@ We use **fixed packages**, as you can see at `.changeset/config.json`:
 
 ```json
 {
-  "fixed": [["kubricate", "@kubricate/core", "@kubricate/env", "@kubricate/stacks", "@kubricate/kubernetes"]],
+  "fixed": [["kubricate", "@kubricate/core", "@kubricate/plugin-env", "@kubricate/stacks", "@kubricate/kubernetes"]],
 }
 ```
 

--- a/docs/monorepo-maintenance-guide.md
+++ b/docs/monorepo-maintenance-guide.md
@@ -21,7 +21,7 @@ We use **fixed packages**, as you can see at `.changeset/config.json`:
 
 ```json
 {
-  "fixed": [["kubricate", "@kubricate/core", "@kubricate/plugin-env", "@kubricate/stacks", "@kubricate/kubernetes"]],
+  "fixed": [["kubricate", "@kubricate/core", "@kubricate/plugin-env", "@kubricate/stacks", "@kubricate/plugin-kubernetes"]],
 }
 ```
 

--- a/examples/with-secret-registry/package.json
+++ b/examples/with-secret-registry/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@kubricate/core": "workspace:*",
     "@kubricate/plugin-env": "workspace:*",
-    "@kubricate/kubernetes": "workspace:*",
+    "@kubricate/plugin-kubernetes": "workspace:*",
     "@kubricate/stacks": "workspace:*",
     "kubernetes-models": "^4.4.2"
   }

--- a/examples/with-secret-registry/package.json
+++ b/examples/with-secret-registry/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@kubricate/core": "workspace:*",
-    "@kubricate/env": "workspace:*",
+    "@kubricate/plugin-env": "workspace:*",
     "@kubricate/kubernetes": "workspace:*",
     "@kubricate/stacks": "workspace:*",
     "kubernetes-models": "^4.4.2"

--- a/examples/with-secret-registry/src/setup-secret.ts
+++ b/examples/with-secret-registry/src/setup-secret.ts
@@ -1,6 +1,6 @@
 import { SecretManager, SecretRegistry } from '@kubricate/core';
 import { OpaqueSecretProvider } from '@kubricate/kubernetes';
-import { EnvConnector } from '@kubricate/env';
+import { EnvConnector } from '@kubricate/plugin-env';
 
 const frontendSecretManager = new SecretManager()
   .addConnector('EnvConnector', new EnvConnector())

--- a/examples/with-secret-registry/src/setup-secret.ts
+++ b/examples/with-secret-registry/src/setup-secret.ts
@@ -1,5 +1,5 @@
 import { SecretManager, SecretRegistry } from '@kubricate/core';
-import { OpaqueSecretProvider } from '@kubricate/kubernetes';
+import { OpaqueSecretProvider } from '@kubricate/plugin-kubernetes';
 import { EnvConnector } from '@kubricate/plugin-env';
 
 const frontendSecretManager = new SecretManager()

--- a/examples/with-secret/package.json
+++ b/examples/with-secret/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@kubricate/core": "workspace:*",
     "@kubricate/plugin-env": "workspace:*",
-    "@kubricate/kubernetes": "workspace:*",
+    "@kubricate/plugin-kubernetes": "workspace:*",
     "@kubricate/stacks": "workspace:*",
     "kubernetes-models": "^4.4.2"
   }

--- a/examples/with-secret/package.json
+++ b/examples/with-secret/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@kubricate/core": "workspace:*",
-    "@kubricate/env": "workspace:*",
+    "@kubricate/plugin-env": "workspace:*",
     "@kubricate/kubernetes": "workspace:*",
     "@kubricate/stacks": "workspace:*",
     "kubernetes-models": "^4.4.2"

--- a/examples/with-secret/src/setup-secrets.ts
+++ b/examples/with-secret/src/setup-secrets.ts
@@ -1,5 +1,5 @@
 import { SecretManager } from '@kubricate/core';
-import { OpaqueSecretProvider, DockerConfigSecretProvider } from '@kubricate/kubernetes';
+import { OpaqueSecretProvider, DockerConfigSecretProvider } from '@kubricate/plugin-kubernetes';
 import { EnvConnector } from '@kubricate/plugin-env';
 
 export const secretManager = new SecretManager()

--- a/examples/with-secret/src/setup-secrets.ts
+++ b/examples/with-secret/src/setup-secrets.ts
@@ -1,6 +1,6 @@
 import { SecretManager } from '@kubricate/core';
 import { OpaqueSecretProvider, DockerConfigSecretProvider } from '@kubricate/kubernetes';
-import { EnvConnector } from '@kubricate/env';
+import { EnvConnector } from '@kubricate/plugin-env';
 
 export const secretManager = new SecretManager()
   .addConnector('EnvConnector', new EnvConnector())

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -371,7 +371,7 @@ Documentation is in progress, please explore the [`examples`](https://github.com
 
 - `kubricate` – CLI for configuration and manifest generation
 - `@kubricate/core` – Core framework for creating and managing stacks
-- `@kubricate/env` – Secret connector for `.env` and environment variables
+- `@kubricate/plugin-env` – Secret connector for `.env` and environment variables
 - `@kubricate/kubernetes` – Kubernetes connectors
 - `@kubricate/stacks` – Official reusable stack definitions
 - `@kubricate/toolkit` – Utility functions for custom stack authors
@@ -382,7 +382,7 @@ Ensure the following packages are always on the same version when upgrading:
 
 - `kubricate`
 - `@kubricate/core`
-- `@kubricate/env`
+- `@kubricate/plugin-env`
 - `@kubricate/kubernetes`
 - `@kubricate/stacks`
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -372,7 +372,7 @@ Documentation is in progress, please explore the [`examples`](https://github.com
 - `kubricate` – CLI for configuration and manifest generation
 - `@kubricate/core` – Core framework for creating and managing stacks
 - `@kubricate/plugin-env` – Secret connector for `.env` and environment variables
-- `@kubricate/kubernetes` – Kubernetes connectors
+- `@kubricate/plugin-kubernetes` – Kubernetes connectors
 - `@kubricate/stacks` – Official reusable stack definitions
 - `@kubricate/toolkit` – Utility functions for custom stack authors
 
@@ -383,7 +383,7 @@ Ensure the following packages are always on the same version when upgrading:
 - `kubricate`
 - `@kubricate/core`
 - `@kubricate/plugin-env`
-- `@kubricate/kubernetes`
+- `@kubricate/plugin-kubernetes`
 - `@kubricate/stacks`
 
 ## Development

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @kubricate/env
+# @kubricate/plugin-env
 
 ## 0.18.1
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -371,7 +371,7 @@ Documentation is in progress, please explore the [`examples`](https://github.com
 
 - `kubricate` – CLI for configuration and manifest generation
 - `@kubricate/core` – Core framework for creating and managing stacks
-- `@kubricate/env` – Secret connector for `.env` and environment variables
+- `@kubricate/plugin-env` – Secret connector for `.env` and environment variables
 - `@kubricate/kubernetes` – Kubernetes connectors
 - `@kubricate/stacks` – Official reusable stack definitions
 - `@kubricate/toolkit` – Utility functions for custom stack authors
@@ -382,7 +382,7 @@ Ensure the following packages are always on the same version when upgrading:
 
 - `kubricate`
 - `@kubricate/core`
-- `@kubricate/env`
+- `@kubricate/plugin-env`
 - `@kubricate/kubernetes`
 - `@kubricate/stacks`
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -372,7 +372,7 @@ Documentation is in progress, please explore the [`examples`](https://github.com
 - `kubricate` – CLI for configuration and manifest generation
 - `@kubricate/core` – Core framework for creating and managing stacks
 - `@kubricate/plugin-env` – Secret connector for `.env` and environment variables
-- `@kubricate/kubernetes` – Kubernetes connectors
+- `@kubricate/plugin-kubernetes` – Kubernetes connectors
 - `@kubricate/stacks` – Official reusable stack definitions
 - `@kubricate/toolkit` – Utility functions for custom stack authors
 
@@ -383,7 +383,7 @@ Ensure the following packages are always on the same version when upgrading:
 - `kubricate`
 - `@kubricate/core`
 - `@kubricate/plugin-env`
-- `@kubricate/kubernetes`
+- `@kubricate/plugin-kubernetes`
 - `@kubricate/stacks`
 
 ## Development

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@kubricate/env",
+  "name": "@kubricate/plugin-env",
   "version": "0.18.1",
   "type": "module",
   "main": "./dist/cjs/index.js",

--- a/packages/kubernetes/CHANGELOG.md
+++ b/packages/kubernetes/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @kubricate/kubernetes
+# @kubricate/plugin-kubernetes
 
 ## 0.18.1
 

--- a/packages/kubernetes/README.md
+++ b/packages/kubernetes/README.md
@@ -371,7 +371,7 @@ Documentation is in progress, please explore the [`examples`](https://github.com
 
 - `kubricate` – CLI for configuration and manifest generation
 - `@kubricate/core` – Core framework for creating and managing stacks
-- `@kubricate/env` – Secret connector for `.env` and environment variables
+- `@kubricate/plugin-env` – Secret connector for `.env` and environment variables
 - `@kubricate/kubernetes` – Kubernetes connectors
 - `@kubricate/stacks` – Official reusable stack definitions
 - `@kubricate/toolkit` – Utility functions for custom stack authors
@@ -382,7 +382,7 @@ Ensure the following packages are always on the same version when upgrading:
 
 - `kubricate`
 - `@kubricate/core`
-- `@kubricate/env`
+- `@kubricate/plugin-env`
 - `@kubricate/kubernetes`
 - `@kubricate/stacks`
 

--- a/packages/kubernetes/README.md
+++ b/packages/kubernetes/README.md
@@ -372,7 +372,7 @@ Documentation is in progress, please explore the [`examples`](https://github.com
 - `kubricate` – CLI for configuration and manifest generation
 - `@kubricate/core` – Core framework for creating and managing stacks
 - `@kubricate/plugin-env` – Secret connector for `.env` and environment variables
-- `@kubricate/kubernetes` – Kubernetes connectors
+- `@kubricate/plugin-kubernetes` – Kubernetes connectors
 - `@kubricate/stacks` – Official reusable stack definitions
 - `@kubricate/toolkit` – Utility functions for custom stack authors
 
@@ -383,7 +383,7 @@ Ensure the following packages are always on the same version when upgrading:
 - `kubricate`
 - `@kubricate/core`
 - `@kubricate/plugin-env`
-- `@kubricate/kubernetes`
+- `@kubricate/plugin-kubernetes`
 - `@kubricate/stacks`
 
 ## Development

--- a/packages/kubernetes/package.json
+++ b/packages/kubernetes/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@kubricate/kubernetes",
+  "name": "@kubricate/plugin-kubernetes",
   "version": "0.18.1",
   "type": "module",
   "main": "./dist/cjs/index.js",

--- a/packages/kubricate/README.md
+++ b/packages/kubricate/README.md
@@ -371,7 +371,7 @@ Documentation is in progress, please explore the [`examples`](https://github.com
 
 - `kubricate` – CLI for configuration and manifest generation
 - `@kubricate/core` – Core framework for creating and managing stacks
-- `@kubricate/env` – Secret connector for `.env` and environment variables
+- `@kubricate/plugin-env` – Secret connector for `.env` and environment variables
 - `@kubricate/kubernetes` – Kubernetes connectors
 - `@kubricate/stacks` – Official reusable stack definitions
 - `@kubricate/toolkit` – Utility functions for custom stack authors
@@ -382,7 +382,7 @@ Ensure the following packages are always on the same version when upgrading:
 
 - `kubricate`
 - `@kubricate/core`
-- `@kubricate/env`
+- `@kubricate/plugin-env`
 - `@kubricate/kubernetes`
 - `@kubricate/stacks`
 

--- a/packages/kubricate/README.md
+++ b/packages/kubricate/README.md
@@ -372,7 +372,7 @@ Documentation is in progress, please explore the [`examples`](https://github.com
 - `kubricate` – CLI for configuration and manifest generation
 - `@kubricate/core` – Core framework for creating and managing stacks
 - `@kubricate/plugin-env` – Secret connector for `.env` and environment variables
-- `@kubricate/kubernetes` – Kubernetes connectors
+- `@kubricate/plugin-kubernetes` – Kubernetes connectors
 - `@kubricate/stacks` – Official reusable stack definitions
 - `@kubricate/toolkit` – Utility functions for custom stack authors
 
@@ -383,7 +383,7 @@ Ensure the following packages are always on the same version when upgrading:
 - `kubricate`
 - `@kubricate/core`
 - `@kubricate/plugin-env`
-- `@kubricate/kubernetes`
+- `@kubricate/plugin-kubernetes`
 - `@kubricate/stacks`
 
 ## Development

--- a/packages/stacks/README.md
+++ b/packages/stacks/README.md
@@ -371,7 +371,7 @@ Documentation is in progress, please explore the [`examples`](https://github.com
 
 - `kubricate` – CLI for configuration and manifest generation
 - `@kubricate/core` – Core framework for creating and managing stacks
-- `@kubricate/env` – Secret connector for `.env` and environment variables
+- `@kubricate/plugin-env` – Secret connector for `.env` and environment variables
 - `@kubricate/kubernetes` – Kubernetes connectors
 - `@kubricate/stacks` – Official reusable stack definitions
 - `@kubricate/toolkit` – Utility functions for custom stack authors
@@ -382,7 +382,7 @@ Ensure the following packages are always on the same version when upgrading:
 
 - `kubricate`
 - `@kubricate/core`
-- `@kubricate/env`
+- `@kubricate/plugin-env`
 - `@kubricate/kubernetes`
 - `@kubricate/stacks`
 

--- a/packages/stacks/README.md
+++ b/packages/stacks/README.md
@@ -372,7 +372,7 @@ Documentation is in progress, please explore the [`examples`](https://github.com
 - `kubricate` – CLI for configuration and manifest generation
 - `@kubricate/core` – Core framework for creating and managing stacks
 - `@kubricate/plugin-env` – Secret connector for `.env` and environment variables
-- `@kubricate/kubernetes` – Kubernetes connectors
+- `@kubricate/plugin-kubernetes` – Kubernetes connectors
 - `@kubricate/stacks` – Official reusable stack definitions
 - `@kubricate/toolkit` – Utility functions for custom stack authors
 
@@ -383,7 +383,7 @@ Ensure the following packages are always on the same version when upgrading:
 - `kubricate`
 - `@kubricate/core`
 - `@kubricate/plugin-env`
-- `@kubricate/kubernetes`
+- `@kubricate/plugin-kubernetes`
 - `@kubricate/stacks`
 
 ## Development

--- a/packages/toolkit/README.md
+++ b/packages/toolkit/README.md
@@ -371,7 +371,7 @@ Documentation is in progress, please explore the [`examples`](https://github.com
 
 - `kubricate` – CLI for configuration and manifest generation
 - `@kubricate/core` – Core framework for creating and managing stacks
-- `@kubricate/env` – Secret connector for `.env` and environment variables
+- `@kubricate/plugin-env` – Secret connector for `.env` and environment variables
 - `@kubricate/kubernetes` – Kubernetes connectors
 - `@kubricate/stacks` – Official reusable stack definitions
 - `@kubricate/toolkit` – Utility functions for custom stack authors
@@ -382,7 +382,7 @@ Ensure the following packages are always on the same version when upgrading:
 
 - `kubricate`
 - `@kubricate/core`
-- `@kubricate/env`
+- `@kubricate/plugin-env`
 - `@kubricate/kubernetes`
 - `@kubricate/stacks`
 

--- a/packages/toolkit/README.md
+++ b/packages/toolkit/README.md
@@ -372,7 +372,7 @@ Documentation is in progress, please explore the [`examples`](https://github.com
 - `kubricate` – CLI for configuration and manifest generation
 - `@kubricate/core` – Core framework for creating and managing stacks
 - `@kubricate/plugin-env` – Secret connector for `.env` and environment variables
-- `@kubricate/kubernetes` – Kubernetes connectors
+- `@kubricate/plugin-kubernetes` – Kubernetes connectors
 - `@kubricate/stacks` – Official reusable stack definitions
 - `@kubricate/toolkit` – Utility functions for custom stack authors
 
@@ -383,7 +383,7 @@ Ensure the following packages are always on the same version when upgrading:
 - `kubricate`
 - `@kubricate/core`
 - `@kubricate/plugin-env`
-- `@kubricate/kubernetes`
+- `@kubricate/plugin-kubernetes`
 - `@kubricate/stacks`
 
 ## Development

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,12 +131,12 @@ importers:
       '@kubricate/core':
         specifier: workspace:*
         version: link:../../packages/core
-      '@kubricate/env':
-        specifier: workspace:*
-        version: link:../../packages/env
       '@kubricate/kubernetes':
         specifier: workspace:*
         version: link:../../packages/kubernetes
+      '@kubricate/plugin-env':
+        specifier: workspace:*
+        version: link:../../packages/env
       '@kubricate/stacks':
         specifier: workspace:*
         version: link:../../packages/stacks
@@ -168,12 +168,12 @@ importers:
       '@kubricate/core':
         specifier: workspace:*
         version: link:../../packages/core
-      '@kubricate/env':
-        specifier: workspace:*
-        version: link:../../packages/env
       '@kubricate/kubernetes':
         specifier: workspace:*
         version: link:../../packages/kubernetes
+      '@kubricate/plugin-env':
+        specifier: workspace:*
+        version: link:../../packages/env
       '@kubricate/stacks':
         specifier: workspace:*
         version: link:../../packages/stacks
@@ -400,12 +400,12 @@ importers:
       '@kubricate/core':
         specifier: workspace:*
         version: link:../packages/core
-      '@kubricate/env':
-        specifier: workspace:*
-        version: link:../packages/env
       '@kubricate/kubernetes':
         specifier: workspace:*
         version: link:../packages/kubernetes
+      '@kubricate/plugin-env':
+        specifier: workspace:*
+        version: link:../packages/env
       '@kubricate/stacks':
         specifier: workspace:*
         version: link:../packages/stacks

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,7 +131,7 @@ importers:
       '@kubricate/core':
         specifier: workspace:*
         version: link:../../packages/core
-      '@kubricate/kubernetes':
+      '@kubricate/plugin-kubernetes':
         specifier: workspace:*
         version: link:../../packages/kubernetes
       '@kubricate/plugin-env':
@@ -168,7 +168,7 @@ importers:
       '@kubricate/core':
         specifier: workspace:*
         version: link:../../packages/core
-      '@kubricate/kubernetes':
+      '@kubricate/plugin-kubernetes':
         specifier: workspace:*
         version: link:../../packages/kubernetes
       '@kubricate/plugin-env':
@@ -400,7 +400,7 @@ importers:
       '@kubricate/core':
         specifier: workspace:*
         version: link:../packages/core
-      '@kubricate/kubernetes':
+      '@kubricate/plugin-kubernetes':
         specifier: workspace:*
         version: link:../packages/kubernetes
       '@kubricate/plugin-env':

--- a/tests/fixtures/shared-configs.ts
+++ b/tests/fixtures/shared-configs.ts
@@ -1,7 +1,7 @@
 import { NamespaceStack, SimpleAppStack } from "@kubricate/stacks";
 import { SecretManager, SecretRegistry } from '@kubricate/core';
 import { OpaqueSecretProvider, DockerConfigSecretProvider } from '@kubricate/kubernetes';
-import { EnvConnector } from '@kubricate/env';
+import { EnvConnector } from '@kubricate/plugin-env';
 
 export const frontendSecretManager = new SecretManager()
   .addConnector('EnvConnector', new EnvConnector())

--- a/tests/fixtures/shared-configs.ts
+++ b/tests/fixtures/shared-configs.ts
@@ -1,6 +1,6 @@
 import { NamespaceStack, SimpleAppStack } from "@kubricate/stacks";
 import { SecretManager, SecretRegistry } from '@kubricate/core';
-import { OpaqueSecretProvider, DockerConfigSecretProvider } from '@kubricate/kubernetes';
+import { OpaqueSecretProvider, DockerConfigSecretProvider } from '@kubricate/plugin-kubernetes';
 import { EnvConnector } from '@kubricate/plugin-env';
 
 export const frontendSecretManager = new SecretManager()

--- a/tests/package.json
+++ b/tests/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@kubricate/core": "workspace:*",
     "@kubricate/plugin-env": "workspace:*",
-    "@kubricate/kubernetes": "workspace:*",
+    "@kubricate/plugin-kubernetes": "workspace:*",
     "@kubricate/stacks": "workspace:*",
     "kubernetes-models": "^4.4.2",
     "kubricate": "workspace:*"

--- a/tests/package.json
+++ b/tests/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@kubricate/core": "workspace:*",
-    "@kubricate/env": "workspace:*",
+    "@kubricate/plugin-env": "workspace:*",
     "@kubricate/kubernetes": "workspace:*",
     "@kubricate/stacks": "workspace:*",
     "kubernetes-models": "^4.4.2",


### PR DESCRIPTION
This PR renames key packages in the Kubricate ecosystem to follow a consistent `@kubricate/plugin-*` naming convention, reflecting their plugin-style role within the framework.

### ✨ What’s Changed

- ✅ `@kubricate/env` → `@kubricate/plugin-env`
- ✅ `@kubricate/kubernetes` → `@kubricate/plugin-kubernetes`
- ✅ Updated all imports, internal references, and re-exports
- ✅ Updated affected examples and documentation

### 📦 Motivation

This change is based on the design proposed in [#114](https://github.com/thaitype/kubricate/issues/114), which defines plugins as:

> “Any optional module that integrates via a core registration interface and extends infrastructure behavior at build time.”

Under this model:
- Connectors, Providers, and PluginProviders are all **user-registered**, **side-effect free**, and **extensible**
- This naming improves discoverability, aligns with community expectations, and enables consistent plugin registration logic

### ✅ Affected Plugin Set

```txt
@kubricate/plugin-env
@kubricate/plugin-kubernetes
```

### 🔧 Migration Plan

| Old Package                     | New Package                      |
|---------------------------------|----------------------------------|
| `@kubricate/env`               | `@kubricate/plugin-env`          |
| `@kubricate/kubernetes`        | `@kubricate/plugin-kubernetes`   |

Update all `import` and `addConnector()` / `addProvider()` references to use the new package names.  
The old packages will be deprecated and unpublished in a future release.

This refactor improves ecosystem consistency and sets the foundation for more scalable plugin integration going forward.