### PR TITLE
fix(kubricate): ensure temporary file cleanup after applying secrets 

### DIFF
--- a/packages/kubricate/src/executor/kubectl-executor.ts
+++ b/packages/kubricate/src/executor/kubectl-executor.ts
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto';
 // kubectl-executor.ts
-import { writeFile } from 'node:fs/promises';
+import { unlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -26,6 +26,14 @@ export class KubectlExecutor {
     } catch (err) {
       this.logger.error(`❌ kubectl apply failed: ${(err as Error).message}`);
       throw err;
+    } finally {
+      // Clean up temp file for security - prevent unauthorized access to secrets
+      try {
+        await unlink(tempPath);
+        this.logger.debug(`Cleaned up temp file: ${tempPath}`);
+      } catch (cleanupErr) {
+        this.logger.warn(`Failed to clean up temp file ${tempPath}: ${(cleanupErr as Error).message}`);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
Temporary secret files created during `kubricate secret apply` are now automatically deleted after kubectl execution, preventing unauthorized access to sensitive data in the OS temp directory.

- [x] Type: fix

## What & Why
**What changed**
- Added automatic cleanup of temporary secret files in `KubectlExecutor.apply()`
- Used `finally` block to ensure cleanup happens even when kubectl apply fails
- Added graceful error handling for cleanup failures (logs warning but doesn't crash)
- Imported `unlink` from `node:fs/promises` for file deletion

**Why (problem / motivation)**
- When `kubricate secret apply` runs, it writes secret JSON to `/tmp/kubricate-secret-<uuid>.json`
- These temp files were never deleted, leaving sensitive credentials (SSH keys, passwords, tokens) accessible
- Unauthorized users with access to the temp directory could read these secrets
- Creates a security vulnerability, especially on shared systems or CI/CD environments

**Linked issues**
- Closes #127

## Screenshots / Demos (if UI or DX)

**Before (security issue):**
```bash
$ kubricate secret apply
✅ Applied secret via kubectl

$ ls -la /tmp/kubricate-secret-*.json
-rw-r--r-- 1 user user 1234 Nov 02 00:10 /tmp/kubricate-secret-abc123.json
# ⚠️ Secret file remains with sensitive data!
```

**After (fixed):**
```bash
$ kubricate secret apply
✅ Applied secret via kubectl

$ ls -la /tmp/kubricate-secret-*.json
ls: cannot access '/tmp/kubricate-secret-*.json': No such file or directory
# ✅ Temp file automatically cleaned up!
```

## How to Test
1. Monitor temp directory: `watch -n 0.5 'ls -la /tmp/kubricate-secret-* 2>/dev/null || echo "No temp files"'`
2. Run `kubricate secret apply` in another terminal
3. Expected: Temp file appears briefly during apply, then is immediately deleted
4. Verify with: `ls -la /tmp/kubricate-secret-*` (should show no files)
5. Test error case: Use invalid kubectl path to trigger failure
6. Expected: Temp file is still cleaned up even when kubectl fails
7. Test with verbose mode: `kubricate secret apply --verbose`
8. Expected: Debug log shows "Cleaned up temp file: /tmp/kubricate-secret-<uuid>.json"

## Breaking Changes?
- [x] No breaking changes

## Performance / Security / Compatibility
- Performance impact: Negligible (adds one async file deletion per secret apply)
- Security considerations: **Major security improvement** - prevents credential leakage in temp directory
  - Cleanup happens in `finally` block (guaranteed execution)
  - Cleanup errors are non-fatal (warns but doesn't crash)
  - Works on all platforms (Windows, macOS, Linux)
- Compatibility: Fully backward compatible, no API changes

## Docs & Changelog
- [x] Code is commented where non-obvious (explains security reason for cleanup)
- [x] Add release note (one clear sentence)

**Release note**
> Fixed security vulnerability where temporary secret files remained in `/tmp` after `kubricate secret apply`, now automatically cleaned up to prevent unauthorized access.

## Checklist
- [x] Follows style & lints pass
- [x] CI green (build, tests, typecheck)
- [x] Manual Test for Recheck the behavior 
- [x] Feature flagged or safe by default (safe by default, cleanup always happens)
- [x] No sensitive data committed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of temporary files created during operations. Temporary files are now reliably deleted after processing completes, preventing disk space accumulation and improving system resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->