### PR TITLE
fix: Fix CLI root parameter

### DIFF
--- a/packages/kubricate/src/cli-interfaces/entrypoint.ts
+++ b/packages/kubricate/src/cli-interfaces/entrypoint.ts
@@ -1,6 +1,7 @@
+import path from 'node:path';
+
 import c from 'ansis';
 import yargs from 'yargs';
-import path from 'node:path';
 import { hideBin } from 'yargs/helpers';
 
 import type { LogLevel } from '@kubricate/core';

--- a/packages/kubricate/src/cli-interfaces/entrypoint.ts
+++ b/packages/kubricate/src/cli-interfaces/entrypoint.ts
@@ -1,5 +1,6 @@
 import c from 'ansis';
 import yargs from 'yargs';
+import path from 'node:path';
 import { hideBin } from 'yargs/helpers';
 
 import type { LogLevel } from '@kubricate/core';
@@ -53,6 +54,7 @@ export function cliEntryPoint(argv: string[], options: CliEntryPointOptions): Pr
       .option('verbose', { type: 'boolean', describe: 'Enable verbose output' })
       .option('silent', { type: 'boolean', describe: 'Suppress all output' })
       .option('dry-run', { type: 'boolean', describe: 'Dry run mode (Not Stable Yet)' })
+      .global(['root', 'config', 'verbose', 'silent', 'dry-run'])
       .middleware(argv => {
         let level: LogLevel = 'info';
         if (argv.silent) level = 'silent';
@@ -60,6 +62,7 @@ export function cliEntryPoint(argv: string[], options: CliEntryPointOptions): Pr
 
         argv.logger = new ConsoleLogger(level);
         argv.version = options.version;
+        argv.root = argv.root ? path.resolve(argv.root) : process.cwd();
       })
       .command(generateCommand)
       .command(secretCommand)

--- a/tests/fixtures/generate-output-non-root-dir/example/kubricate.config.ts
+++ b/tests/fixtures/generate-output-non-root-dir/example/kubricate.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'kubricate';
+
+import { metadata, sharedStacks } from '../../shared-configs';
+
+export default defineConfig({
+  stacks: {
+    namespace: sharedStacks.namespace,
+    frontend: sharedStacks.frontend,
+  },
+  generate: {
+    outputMode: 'resource',
+  },
+  metadata,
+});

--- a/tests/integration/__snapshots__/generate-to-files.test.ts.snap
+++ b/tests/integration/__snapshots__/generate-to-files.test.ts.snap
@@ -286,7 +286,7 @@ metadata:
 "
 `;
 
-exports[`CLI Integration (non-root directory) > should generate expected files > generate-output-non-root-dir/example/output/frontend/Deployment_deployment.yml 1`] = `
+exports[`CLI Integration (non-root directory) > should generate expected files when run from different cwd > generate-output-non-root-dir/example/output/frontend/Deployment_deployment.yml 1`] = `
 "apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -318,7 +318,7 @@ spec:
 "
 `;
 
-exports[`CLI Integration (non-root directory) > should generate expected files > generate-output-non-root-dir/example/output/frontend/Service_service.yml 1`] = `
+exports[`CLI Integration (non-root directory) > should generate expected files when run from different cwd > generate-output-non-root-dir/example/output/frontend/Service_service.yml 1`] = `
 "apiVersion: v1
 kind: Service
 metadata:
@@ -342,7 +342,7 @@ spec:
 "
 `;
 
-exports[`CLI Integration (non-root directory) > should generate expected files > generate-output-non-root-dir/example/output/namespace/Namespace_namespace.yml 1`] = `
+exports[`CLI Integration (non-root directory) > should generate expected files when run from different cwd > generate-output-non-root-dir/example/output/namespace/Namespace_namespace.yml 1`] = `
 "apiVersion: v1
 kind: Namespace
 metadata:

--- a/tests/integration/__snapshots__/generate-to-files.test.ts.snap
+++ b/tests/integration/__snapshots__/generate-to-files.test.ts.snap
@@ -285,3 +285,75 @@ metadata:
 ---
 "
 `;
+
+exports[`CLI Integration (non-root directory) > should generate expected files > generate-output-non-root-dir/example/output/frontend/Deployment_deployment.yml 1`] = `
+"apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+  namespace: my-namespace
+  labels:
+    kubricate.thaitype.dev: "true"
+    kubricate.thaitype.dev/stack-id: frontend
+    kubricate.thaitype.dev/resource-id: deployment
+  annotations:
+    kubricate.thaitype.dev/stack-name: SimpleApp
+    kubricate.thaitype.dev/resource-hash: 84241ff01519b9522ccbd4f2cdf8d22d850a7c7af3aba576447dd0157ab07adf
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-app
+  template:
+    metadata:
+      labels:
+        app: my-app
+    spec:
+      containers:
+        - image: nginx
+          name: my-app
+          ports:
+            - containerPort: 80
+---
+"
+`;
+
+exports[`CLI Integration (non-root directory) > should generate expected files > generate-output-non-root-dir/example/output/frontend/Service_service.yml 1`] = `
+"apiVersion: v1
+kind: Service
+metadata:
+  name: my-app
+  namespace: my-namespace
+  labels:
+    kubricate.thaitype.dev: "true"
+    kubricate.thaitype.dev/stack-id: frontend
+    kubricate.thaitype.dev/resource-id: service
+  annotations:
+    kubricate.thaitype.dev/stack-name: SimpleApp
+    kubricate.thaitype.dev/resource-hash: 89a63d5a0e71a81f00e668fd1fccee5103200d731e8b1a3546f31e06eb639fe7
+spec:
+  selector:
+    app: my-app
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 80
+---
+"
+`;
+
+exports[`CLI Integration (non-root directory) > should generate expected files > generate-output-non-root-dir/example/output/namespace/Namespace_namespace.yml 1`] = `
+"apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-namespace
+  labels:
+    kubricate.thaitype.dev: "true"
+    kubricate.thaitype.dev/stack-id: namespace
+    kubricate.thaitype.dev/resource-id: namespace
+  annotations:
+    kubricate.thaitype.dev/stack-name: Namespace
+    kubricate.thaitype.dev/resource-hash: 3492d8e193f760528e44917ab2f004d6a9eed4bae268a2f6fb965eb802d28914
+---
+"
+`;

--- a/tests/integration/__snapshots__/generate-to-files.test.ts.snap
+++ b/tests/integration/__snapshots__/generate-to-files.test.ts.snap
@@ -286,6 +286,78 @@ metadata:
 "
 `;
 
+exports[`CLI Integration (non-root directory) > should generate expected files when --root is not provided (default to cwd) > generate-output-non-root-dir/example/output/frontend/Deployment_deployment.yml 1`] = `
+"apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+  namespace: my-namespace
+  labels:
+    kubricate.thaitype.dev: "true"
+    kubricate.thaitype.dev/stack-id: frontend
+    kubricate.thaitype.dev/resource-id: deployment
+  annotations:
+    kubricate.thaitype.dev/stack-name: SimpleApp
+    kubricate.thaitype.dev/resource-hash: 84241ff01519b9522ccbd4f2cdf8d22d850a7c7af3aba576447dd0157ab07adf
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-app
+  template:
+    metadata:
+      labels:
+        app: my-app
+    spec:
+      containers:
+        - image: nginx
+          name: my-app
+          ports:
+            - containerPort: 80
+---
+"
+`;
+
+exports[`CLI Integration (non-root directory) > should generate expected files when --root is not provided (default to cwd) > generate-output-non-root-dir/example/output/frontend/Service_service.yml 1`] = `
+"apiVersion: v1
+kind: Service
+metadata:
+  name: my-app
+  namespace: my-namespace
+  labels:
+    kubricate.thaitype.dev: "true"
+    kubricate.thaitype.dev/stack-id: frontend
+    kubricate.thaitype.dev/resource-id: service
+  annotations:
+    kubricate.thaitype.dev/stack-name: SimpleApp
+    kubricate.thaitype.dev/resource-hash: 89a63d5a0e71a81f00e668fd1fccee5103200d731e8b1a3546f31e06eb639fe7
+spec:
+  selector:
+    app: my-app
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 80
+---
+"
+`;
+
+exports[`CLI Integration (non-root directory) > should generate expected files when --root is not provided (default to cwd) > generate-output-non-root-dir/example/output/namespace/Namespace_namespace.yml 1`] = `
+"apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-namespace
+  labels:
+    kubricate.thaitype.dev: "true"
+    kubricate.thaitype.dev/stack-id: namespace
+    kubricate.thaitype.dev/resource-id: namespace
+  annotations:
+    kubricate.thaitype.dev/stack-name: Namespace
+    kubricate.thaitype.dev/resource-hash: 3492d8e193f760528e44917ab2f004d6a9eed4bae268a2f6fb965eb802d28914
+---
+"
+`;
+
 exports[`CLI Integration (non-root directory) > should generate expected files when run from different cwd > generate-output-non-root-dir/example/output/frontend/Deployment_deployment.yml 1`] = `
 "apiVersion: apps/v1
 kind: Deployment

--- a/tests/integration/generate-to-files.test.ts
+++ b/tests/integration/generate-to-files.test.ts
@@ -64,9 +64,15 @@ describe('CLI Integration (non-root directory)', () => {
     await rimraf(outputFixtureDir);
   });
 
-  it('should generate expected files', async () => {
-    const args = ['generate', '--root', fixturesDir];
-    const { stdout, exitCode } = await executeKubricate(args, { reject: false });
+  it('should generate expected files when run from different cwd', async () => {
+    // Run from a DIFFERENT directory than where the config exists
+    const differentCwd = path.join(fixturesRoot, fixture); // Parent directory
+    const args = ['generate', '--root', './example']; // Relative path to trigger bug
+    
+    const { stdout, exitCode } = await executeKubricate(args, { 
+      reject: false,
+      cwd: differentCwd  // This is the key change!
+    });
 
     expect(exitCode).toBe(0);
     expect(stdout).toContain('Generating stacks');

--- a/tests/integration/generate-to-files.test.ts
+++ b/tests/integration/generate-to-files.test.ts
@@ -53,3 +53,24 @@ describe.each(scenarios)('CLI Integration ($name)', ({ fixture }) => {
     await snapshotDirectory(outputFixtureDir, `${fixture}/${outputDir}`);
   });
 });
+
+describe('CLI Integration (non-root directory)', () => {
+  const fixture = 'generate-output-non-root-dir';
+  const fixturesDir = path.join(fixturesRoot, fixture, 'example');
+  const outputDir = 'output';
+  const outputFixtureDir = path.join(fixturesDir, outputDir);
+
+  afterEach(async () => {
+    await rimraf(outputFixtureDir);
+  });
+
+  it('should generate expected files', async () => {
+    const args = ['generate', '--root', fixturesDir];
+    const { stdout, exitCode } = await executeKubricate(args, { reject: false });
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('Generating stacks');
+
+    await snapshotDirectory(outputFixtureDir, `${fixture}/example/${outputDir}`);
+  });
+});

--- a/tests/integration/generate-to-files.test.ts
+++ b/tests/integration/generate-to-files.test.ts
@@ -65,13 +65,12 @@ describe('CLI Integration (non-root directory)', () => {
   });
 
   it('should generate expected files when run from different cwd', async () => {
-    // Run from a DIFFERENT directory than where the config exists
-    const differentCwd = path.join(fixturesRoot, fixture); // Parent directory
-    const args = ['generate', '--root', './example']; // Relative path to trigger bug
+    const differentCwd = path.join(fixturesRoot, fixture);
+    const args = ['generate', '--root', './example'];
     
     const { stdout, exitCode } = await executeKubricate(args, { 
       reject: false,
-      cwd: differentCwd  // This is the key change!
+      cwd: differentCwd 
     });
 
     expect(exitCode).toBe(0);
@@ -79,4 +78,16 @@ describe('CLI Integration (non-root directory)', () => {
 
     await snapshotDirectory(outputFixtureDir, `${fixture}/example/${outputDir}`);
   });
+
+  it('should generate expected files when --root is not provided (default to cwd)', async () => {
+    const { stdout, exitCode } = await executeKubricate(['generate'], {
+      reject: false,
+      cwd: fixturesDir
+    })
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('Generating stacks');
+
+    await snapshotDirectory(outputFixtureDir, `${fixture}/example/${outputDir}`);
+  })
 });


### PR DESCRIPTION
<!--
Thank you for contributing! Keep the top section short for reviewers.
Use draft PRs for WIP. Link issues with keywords: "Closes #123", "Fixes #456".
-->

## TL;DR

Fixes #130


## What & Why

### What changed
- adding `global` to `entryPoints` and resolving directory path in `middleware`.
- add test for checking running generate with non-root directory

## Linked issues
- Closes #130


## Screenshots / Demos (if UI or DX)
<!-- Before / After images, GIFs, terminal output, sample usage -->

## How to Test
1. Setup directory with non-root kubricate directory like #45 
2. Run `kubricate generate --root /path/to/dir`
3. Expected: Should generate file based on `kubricate.config.ts` in that directory

## Breaking Changes?
- [x] No breaking changes
- [ ] Yes – describe impact & migration below

## Performance / Security / Compatibility
- Performance impact: (none / faster / slower; add numbers if available)
- Security considerations: (inputs validated? secrets? perms?)
- Compatibility: (Node/K8s/Browser versions, APIs, CLI flags, config)

## Docs & Changelog
- [ ] Code is commented where non-obvious
- [ ] Docs updated (README / website / examples)
- [ ] Add release note (one clear sentence)

## Checklist
- [x] Follows style & lints pass
- [x] Unit/integration tests added or not needed
- [ ] CI green (build, tests, typecheck)
- [x] Feature flagged or safe by default
- [x] No sensitive data committed

<!-- Maintainer notes (optional) – keep below the fold -->
<details>
<summary>Maintainer checklist</summary>

- Labels: `type/*`, `area/*`, `semver/*`
- Milestone set
- Changelog entry generated
- Squash & merge with conventional title
- Backport? (if applicable)

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Common CLI options (root, config, verbose, silent, dry-run) are now global.
  * The CLI normalizes the root path at runtime, resolving relative roots to absolute paths and defaulting to the current working directory.
  * Improved support for configurations located in non-root directories.

* **Tests**
  * Added integration tests validating CLI behavior and generation when using non-root directory configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->